### PR TITLE
Disable xdebug

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -21,8 +21,8 @@ COPY php-fpm/wp-cli.yaml /config/wp-cli.yaml
 COPY php-fpm/php.ini /usr/local/etc/php/php.ini
 
 # move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
-COPY php-fpm/xdebug.ini /usr/local/php/docker-php-ext-xdebug.ini
+COPY php-fpm/xdebug.ini /usr/local/php/docker-php-ext-xdebug.ini.template
 
-COPY php-fpm/run-php-fpm.sh /usr/local/bin/run-php-fpm.sh
+COPY php-fpm/run.sh /usr/local/bin/run.sh
 
-CMD ["run-php-fpm.sh"]
+CMD ["run.sh"]

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -21,7 +21,7 @@ COPY php-fpm/wp-cli.yaml /config/wp-cli.yaml
 COPY php-fpm/php.ini /usr/local/etc/php/php.ini
 
 # move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
-COPY php-fpm/xdebug.ini /usr/local/php/docker-php-ext-xdebug.ini.template
+COPY php-fpm/xdebug.ini /usr/local/php/conf.d/docker-php-ext-xdebug.ini.template
 
 COPY php-fpm/run.sh /usr/local/bin/run.sh
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -20,6 +20,9 @@ COPY php-fpm/wp-cli.yaml /config/wp-cli.yaml
 
 COPY php-fpm/php.ini /usr/local/etc/php/php.ini
 
-COPY php-fpm/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
+COPY php-fpm/xdebug.ini /usr/local/php/docker-php-ext-xdebug.ini
 
-CMD ["php-fpm"]
+COPY php-fpm/run-php-fpm.sh /usr/local/bin/run-php-fpm.sh
+
+CMD ["run-php-fpm.sh"]

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -21,7 +21,7 @@ COPY php-fpm/wp-cli.yaml /config/wp-cli.yaml
 COPY php-fpm/php.ini /usr/local/etc/php/php.ini
 
 # move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
-COPY php-fpm/xdebug.ini /usr/local/php/conf.d/docker-php-ext-xdebug.ini.template
+COPY php-fpm/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
 
 COPY php-fpm/run.sh /usr/local/bin/run.sh
 

--- a/php-fpm/run-php-fpm.sh
+++ b/php-fpm/run-php-fpm.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+XDEBUG_CONFIG_LOCATION=/usr/local/php/docker-php-ext-xdebug.ini
+XDEBUG_CONFIG_TARGET_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+if [ "enable" == "$XDEBUG" ]; then
+    echo "Enabling XDebug"
+
+    cp $XDEBUG_CONFIG_LOCATION $XDEBUG_CONFIG_TARGET_LOCATION
+else
+    echo "Disabling XDebug"
+
+    if [ -e $XDEBUG_CONFIG_TARGET_LOCATION ]; then
+        rm -f $XDEBUG_CONFIG_TARGET_LOCATION
+    fi
+fi
+
+
+php-fpm

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/php/docker-php-ext-xdebug.ini.template
+XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/php/conf.d/docker-php-ext-xdebug.ini.template
 XDEBUG_CONFIG_TARGET_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 if [ "enable" == "$XDEBUG" ]; then

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
-XDEBUG_CONFIG_LOCATION=/usr/local/php/docker-php-ext-xdebug.ini
+XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/php/docker-php-ext-xdebug.ini.template
 XDEBUG_CONFIG_TARGET_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 if [ "enable" == "$XDEBUG" ]; then
     echo "Enabling XDebug"
 
-    cp $XDEBUG_CONFIG_LOCATION $XDEBUG_CONFIG_TARGET_LOCATION
+    cp $XDEBUG_CONFIG_TEMPLATE_LOCATION $XDEBUG_CONFIG_TARGET_LOCATION
 else
     echo "Disabling XDebug"
 

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/php/conf.d/docker-php-ext-xdebug.ini.template
+XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
 XDEBUG_CONFIG_TARGET_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 if [ "enable" == "$XDEBUG" ]; then


### PR DESCRIPTION
This "disables" xdebug unles env variable `XDEBUG=enable`.

I am not sure if removing xdebug.ini is the best way, but it gets away with the warning at least.

Follow-up in vip: https://github.com/Automattic/vip/pull/838

This can go out first. It will disable the xdebug on all the new environments without a nice way of enabling it. That is ok I think? Because we want xdebug disabled by default.