### PR TITLE
Updating dev-tools config defaults and bumping version to 0.6

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -34,4 +34,4 @@ jobs:
           # Setting version tag manually
           tags: |
             ghcr.io/automattic/vip-container-images/dev-tools:latest
-            ghcr.io/automattic/vip-container-images/dev-tools:0.5
+            ghcr.io/automattic/vip-container-images/dev-tools:0.6

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -51,10 +51,6 @@ if ( ! defined( 'WPCOM_IS_VIP_ENV' ) ) {
 	define( 'WPCOM_IS_VIP_ENV', false );
 }
 
-if ( ! defined( 'A8C_PROXIED_REQUEST' ) ) {
-	define( 'A8C_PROXIED_REQUEST', true );
-}
-
 if ( ! defined( 'FILES_CLIENT_SITE_ID' ) ) {
 	define( 'FILES_CLIENT_SITE_ID', 200508 );
 }

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -48,12 +48,12 @@ if ( ! defined( 'WP_CRON_CONTROL_SECRET' ) ) {
  * VIP Env variables
  */
 if ( ! defined( 'WPCOM_IS_VIP_ENV' ) ) {
-	define( 'WPCOM_IS_VIP_ENV', true );
+	define( 'WPCOM_IS_VIP_ENV', false );
 }
 
 if ( ! defined( 'A8C_PROXIED_REQUEST' ) ) {
-	define( 'A8C_PROXIED_REQUEST', true ); 
-}   
+	define( 'A8C_PROXIED_REQUEST', true );
+}
 
 if ( ! defined( 'FILES_CLIENT_SITE_ID' ) ) {
 	define( 'FILES_CLIENT_SITE_ID', 200508 );
@@ -71,15 +71,18 @@ if ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {
 }
 
 /**
- * VIP Search
+ * Enterprise Search
  */
-if ( ! defined( 'USE_VIP_ELASTICSEARCH' ) ) {
-	define( 'USE_VIP_ELASTICSEARCH', true );
+/*
+// Uncomment following code in order to enable Enterprise Search
+if ( ! defined( 'VIP_ENABLE_VIP_SEARCH' ) ) {
+	define( 'VIP_ENABLE_VIP_SEARCH', true );
 }
 
 if ( ! defined( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION' ) ) {
 	define( 'VIP_ENABLE_ELASTICSEARCH_QUERY_INTEGRATION', true );
 }
+*/
 
 if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
 	define( 'VIP_ELASTICSEARCH_ENDPOINTS', [


### PR DESCRIPTION
Moving the latest version of the `wp-config-defaults.php` file from `vip dev-env` to the Docker image.

This PR also bumps de dev-tools version to 0.6.