### PR TITLE
Adding Dry Runs on all workflows

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -1,9 +1,10 @@
-name: Publish dev-tools Docker image
+name: Build Developer Tools
 
 on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:
@@ -30,7 +31,8 @@ jobs:
         with:
           file: dev-tools/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           # Setting version tag manually
           tags: |
             ghcr.io/automattic/vip-container-images/dev-tools:latest

--- a/.github/workflows/mu-plugins.yml
+++ b/.github/workflows/mu-plugins.yml
@@ -1,4 +1,4 @@
-name: Publish mu-plugins Docker image
+name: Build MU Plugins
 
 on:
   push:
@@ -30,7 +30,8 @@ jobs:
         with:
           file: mu-plugins/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           # We always pull the latest commit from master
           tags: |
             ghcr.io/automattic/vip-container-images/mu-plugins:latest

--- a/.github/workflows/mu-plugins.yml
+++ b/.github/workflows/mu-plugins.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,4 +1,4 @@
-name: Publish nginx Docker image
+name: Build Nginx
 
 on:
   push:
@@ -33,7 +33,8 @@ jobs:
         with:
           file: nginx/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/nginx:latest
             ghcr.io/automattic/vip-container-images/nginx:${{ steps.getversion.outputs.version }}

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -1,4 +1,4 @@
-name: Publish php-fpm Docker image
+name: Build PHP-FPM
 
 on:
   push:
@@ -33,7 +33,8 @@ jobs:
         with:
           file: php-fpm/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/php-fpm:latest
             ghcr.io/automattic/vip-container-images/php-fpm:${{ steps.getversion.outputs.version }}

--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -1,4 +1,4 @@
-name: Publish skeleton Docker image
+name: Build Skeleton
 
 on:
   push:
@@ -30,7 +30,8 @@ jobs:
         with:
           file: skeleton/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           # We always pull the latest commit from master
           tags: |
             ghcr.io/automattic/vip-container-images/skeleton:latest

--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -1,4 +1,4 @@
-name: Publish statsd Docker image
+name: Build Statsd
 
 on:
   push:
@@ -33,7 +33,8 @@ jobs:
         with:
           file: statsd/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/statsd:latest
             ghcr.io/automattic/vip-container-images/statsd:${{ steps.getversion.outputs.version }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -1,4 +1,4 @@
-name: Publish VIP Wordpress Docker Image
+name: Build WordPress
 
 on:
   push:
@@ -31,7 +31,8 @@ jobs:
           file: wordpress/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: wordpress/public/5.7.2
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/wordpress:5.7.2
       - name: Build 5.8 container image
@@ -40,6 +41,7 @@ jobs:
           file: wordpress/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: wordpress/public/5.8
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/wordpress:5.8

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   push_to_registry:

--- a/wordpress/add-version.sh
+++ b/wordpress/add-version.sh
@@ -53,7 +53,8 @@ cat <<EOT >> .github/workflows/wordpress.yml
           file: wordpress/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: wordpress/public/${version}
-          push: true
+          # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
+          push: ${{ github.base_ref == null }}
           tags: |
             ghcr.io/automattic/vip-container-images/wordpress:${version}
 EOT


### PR DESCRIPTION
This PR adds dry runs to all images. That is, whenever we open a PR, we will try to build the images on a GitHub Action but we will no push them. This way, we can tell whether the image is properly set up.