### PR TITLE
Disable statsd conditionally

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo "Checking for database connectivity..."
-echo "SELECT 'testing_db'"  | mysql -h $db_host -u wordpress -pwordpress wordpress
+echo "SELECT 'testing_db'" | mysql -h $db_host -u wordpress -pwordpress wordpress
 if [ $? -ne 0 ]; then
   echo "No WordPress database exists, provisioning..."
   echo "GRANT ALL ON *.* TO 'wordpress'@'localhost' IDENTIFIED BY 'wordpress' WITH GRANT OPTION;" | mysql -h $db_host -u root

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -97,9 +97,15 @@ if ( ! defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) {
 /**
  * StatsD
  */
+
+if ( ! defined( 'VIP_DISABLE_STATSD' ) ) {
+	define( 'VIP_DISABLE_STATSD', getenv( 'STATSD' ) === 'disable' );
+}
+
 if ( ! defined( 'VIP_STATSD_HOST' ) ) {
 	define( 'VIP_STATSD_HOST', 'statsd' );
 }
+
 if ( ! defined( 'VIP_STATSD_PORT' ) ) {
 	define( 'VIP_STATSD_PORT', 8126 );
 }


### PR DESCRIPTION
This PR sets `VIP_DISABLE_STATSD` flag conditioned to an environment variable. We are making this change to accommodate the fact that we don't always enable statsd on the dev environment.