### PR TITLE
Add GD Graphics Library to php-fpm image

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -6,6 +6,8 @@ RUN apk update && \
     yes '' | pecl install -f memcache && \
     docker-php-ext-install mysqli && \
     docker-php-ext-enable memcache && \
+    apk add libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev gd && \
+    docker-php-ext-install gd && \
     wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar && \
     chmod a+x /usr/local/bin/phpunit && \
     wget -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,12 +1,11 @@
 FROM php:7.4-fpm-alpine3.14
 
 RUN apk update && \
-    apk add --no-cache less bash mariadb-client && \
-    apk add --no-cache --virtual build-deps $PHPIZE_DEPS build-base zlib-dev libffi-dev openssl-dev && \
+    apk add --no-cache less bash mariadb-client gd && \
+    apk add --no-cache --virtual build-deps $PHPIZE_DEPS build-base zlib-dev libffi-dev openssl-dev libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev && \
     yes '' | pecl install -f memcache && \
     docker-php-ext-install mysqli && \
     docker-php-ext-enable memcache && \
-    apk add libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev gd && \
     docker-php-ext-install gd && \
     wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar && \
     chmod a+x /usr/local/bin/phpunit && \


### PR DESCRIPTION
Some development tools - such as [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator) - relies on GD Graphics Library to be available to generate product images, as such it's useful to be available on the development environment. 

This PR includes this library on the `php-fpm` image.

I have tested this with `dev-env` locally, and it works as expected. 