### PR TITLE
Change nginx image path to wp-content

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -56,7 +56,7 @@ server {
     fastcgi_pass php:9000;
   }
 
-  location ~* \.(png|jpg|jpeg|gif|ico)$ {
+  location ~* /wp-content/uploads {
     expires max;
     log_not_found off;
   }


### PR DESCRIPTION
In prod we redirect anything under `/wp-content/uploads` to the file service - so not to `php` code. Let's do something similar on dev-env.