### PR TITLE
Dont copy dev-env-plugin as part of setup

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -36,4 +36,4 @@ jobs:
           # Setting version tag manually
           tags: |
             ghcr.io/automattic/vip-container-images/dev-tools:latest
-            ghcr.io/automattic/vip-container-images/dev-tools:0.6
+            ghcr.io/automattic/vip-container-images/dev-tools:0.7

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -74,6 +74,3 @@ if [ $? -ne 0 ]; then
 
   wp --allow-root user add-cap 1 view_query_monitor
 fi
-
-echo "Copying dev-env-plugin.php to mu-plugins"
-cp /dev-tools/dev-env-plugin.php /wp/wp-content/mu-plugins/


### PR DESCRIPTION
To copy the dev-env plugin we need root permissions (because mu-plugins are mapped and they are owned by root).

With the latest change of the template we are changing the setup to **not** run as root and do the copy in a seperate task.

More info in here - https://github.com/Automattic/vip/pull/888 