### PR TITLE
Override WP_HOME and WP_SITEURL with the values from _SERVER['HTTP_HOST'] (if set), so that magic proxying magically works

### DIFF
--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -6,12 +6,12 @@
 /**
  * Override WP_HOME and WP_SITEURL with the values from $_SERVER['HTTP_HOST'] if it's set.
  *
- * This is needed for the cases where something is already bound to default 80 or 443 ports and Lando's proxy falls back onto a different empty port.
+ * This is needed for the cases where something is already bound to default 80 or 443 ports and Lando's proxy falls back onto a different available port.
  * Defining these constants allows us to force WordPress to use the proper port instead of the default.
  *
  * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
  */
-if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+if ( isset( $_SERVER['HTTP_HOST'] ) && count( explode( ':', $_SERVER['HTTP_HOST'] ) ) === 2 ) {
 	$proto = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'http';
 	define( 'WP_HOME', $proto . '://' . $_SERVER['HTTP_HOST'] );
 	define( 'WP_SITEURL', $proto . '://' . $_SERVER['HTTP_HOST'] );


### PR DESCRIPTION
Lando has this neat thing where its proxy automatically falls back on a different port in case the default one is already bound to something else.

However, we didn't propagate that change to WordPress leading to redirect loops or broken assets. 

This PR addresses that by explicitly set WP_HOME and WP_SITEURL with the values that are in $_SERVER['HTTP_HOST'].

I.e. if the proxy exposes `http://what-mu.vipdev.lndo.site:8000` the $_SERVER['HTTP_HOST'] will get `what-mu.vipdev.lndo.site:8000`, which we, in turn, define as both home and siteurl.

Props @WPprodigy for the idea. 
