### PR TITLE
nginx config change to handle wp-admin

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -30,9 +30,15 @@ server {
     access_log off;
   }
 
+  location ~ wp-admin$ {
+    # If we are requesting wp-admin folder we would redirect to wp-admin/ but always on port 80
+    # This is an extra block to cover common case (wp-admin) when non-standard port is used
+    return 301 $scheme://$http_host$uri/;
+  }
+
   location / {
-    # This is cool because no php is touched for static content.
-    # include the "?$args" part so non-default permalinks doesn't break when using query string
+    # Lets try the file first if it doesnt exist lets try the same + / => the folder
+    # Note that this will always redirect using port 80 (port of the nginx default_server)
     try_files $uri $uri/ /index.php?$args;
   }
 


### PR DESCRIPTION
This is follow-up on https://github.com/Automattic/vip-container-images/pull/28 as an initiative to support non-standard ports.

The previous PR suppresses redirects from WP. However, there are some cases when nginx does the redirect and it would use its default_server port (80) when doing so.

The most notable case is when user goes to `/wp-admin` path. This would nginx redirect to `/wp-admin/`. Wich is what we wont but we need to preserve the port number. 

I tried several more general approaches always ending in failure in a form of infinite redirects or similar fun stuff. So in the end I settled for this solution where we have explicit exception for `wp-admin$`.
