### PR TITLE
Explicitly defines which 2FA providers are able to be used in the dev…

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -8,3 +8,13 @@ add_filter( 'set_url_scheme', function( $url ) {
     }
     return $url;
 });
+
+// Limited Two-Factor Profiders for the dev-env
+add_filter('two_factor_providers', function() {
+    return array(
+        'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class-two-factor-email.php',
+        'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class-two-factor-totp.php',
+        'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class-two-factor-backup-codes.php',
+        'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class-two-factor-dummy.php',
+    );
+});

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -9,12 +9,8 @@ add_filter( 'set_url_scheme', function( $url ) {
     return $url;
 });
 
-// Limited Two-Factor Profiders for the dev-env
-add_filter('two_factor_providers', function() {
-    return array(
-        'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class-two-factor-email.php',
-        'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class-two-factor-totp.php',
-        'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class-two-factor-backup-codes.php',
-        'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class-two-factor-dummy.php',
-    );
+// Disable Two_Factor_FIDO_U2F Profider for the dev-env
+add_filter('two_factor_providers', function( $providers ) {
+    unset( $providers['Two_Factor_FIDO_U2F'] );
+    return $providers;
 });


### PR DESCRIPTION
  * Removes the use of the problem FIDO U2F 2FA provider while in the dev-env image
  * Fixes the issue where a NOTICE (stack trace) gets printed to the console during the first time the environment is started.
  * I have tested this solution in the local dev-env and it seems to work great.
    *![Screen Shot 2021-11-01 at 3 25 33 PM](https://user-images.githubusercontent.com/46167019/139744198-a9051685-32bb-47fa-aa67-ba46dd6bc927.png)

 