### PR TITLE
Add WP Test Runner image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,8 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "wp-test-runner/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/wp-test-runner.yml
+++ b/.github/workflows/wp-test-runner.yml
@@ -1,0 +1,54 @@
+name: Build WP Test Runner image
+
+on:
+  schedule:
+    - cron: '45 10 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - "wp-test-runner/**"
+      - ".github/workflows/wp-test-runner.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "wp-test-runner/**"
+      - ".github/workflows/wp-test-runner.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v2.3.5
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Set up Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ghcr.io/automattic/vip-container-images/wp-test-runner
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: wp-test-runner
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/wp-test-runner.yml
+++ b/.github/workflows/wp-test-runner.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -48,7 +48,6 @@ jobs:
         uses: docker/build-push-action@v2.7.0
         with:
           context: wp-test-runner
-          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -1,0 +1,44 @@
+FROM cimg/base:stable-20.04
+
+USER root
+RUN \
+	export DEBIAN_FRONTEND=noninteractive; \
+	apt-get -qq update && apt-get -y upgrade && \
+	add-apt-repository -y ppa:ondrej/php && \
+	apt-get -qq install php7.4 php7.4-apcu php7.4-curl php7.4-gd php7.4-gmp php7.4-igbinary php7.4-imagick php7.4-imap php7.4-intl php7.4-mbstring php7.4-mysql php7.4-sqlite3 php7.4-xdebug php7.4-xml php7.4-xsl php7.4-zip && \
+	apt-get -qq install php8.0 php8.0-apcu php8.0-curl php8.0-gd php8.0-gmp php8.0-igbinary php8.0-imagick php8.0-imap php8.0-intl php8.0-mbstring php8.0-mysql php8.0-sqlite3 php8.0-xdebug php8.0-xml php8.0-xsl php8.0-zip && \
+	apt-get -qq install php8.1 php8.1-curl php8.1-gd php8.1-gmp php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xml php8.1-zip && \
+	apt-get -qq install subversion unzip default-mysql-client nodejs npm && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
+	echo "xdebug.mode=coverage" >> /etc/php/7.4/mods-available/xdebug.ini && \
+	echo "xdebug.mode=coverage" >> /etc/php/8.0/mods-available/xdebug.ini && \
+	update-alternatives --set php /usr/bin/php7.4
+
+RUN \
+	install -d -o circleci -g circleci -m 0777 /wordpress && \
+	wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/bin/ --filename=composer
+
+RUN \
+	wget -q -O /usr/local/bin/phpunit7 https://phar.phpunit.de/phpunit-7.phar && chmod +x /usr/local/bin/phpunit7 && \
+	wget -q -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && chmod +x /usr/local/bin/phpunit8 && \
+	wget -q -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && chmod +x /usr/local/bin/phpunit9
+
+COPY install-wp.sh /usr/local/bin/install-wp
+
+USER circleci
+
+RUN composer global require phpunit/phpunit:^7 yoast/phpunit-polyfills:^1
+
+RUN \
+	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]') latest; do \
+		install-wp "${version}" & \
+	done && \
+	wait
+
+RUN install-wp nightly
+
+USER root
+COPY runner.sh /usr/local/bin/runner
+ENTRYPOINT ["/usr/local/bin/runner"]
+
+USER circleci

--- a/wp-test-runner/install-wp.sh
+++ b/wp-test-runner/install-wp.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -x
+set -e
+
+download_wp() {
+	VERSION="$1"
+	if [ "${VERSION}" = "nightly" ]; then
+		TESTS_TAG="trunk"
+	elif [ "${VERSION}" = "latest" ]; then
+		VERSIONS=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - )
+		LATEST=$(echo "${VERSIONS}" | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')
+		if [ -z "${LATEST}" ]; then
+			echo "Unable to detect the latest WP version"
+			exit 1
+		fi
+		TESTS_TAG="tags/${LATEST}"
+	else
+		TESTS_TAG="tags/${VERSION}"
+	fi
+
+	if [ ! -d "/wordpress/wordpress-${VERSION}" ]; then
+		if [ "${VERSION}" = "nightly" ]; then
+			cd /wordpress
+			wget -q https://wordpress.org/nightly-builds/wordpress-latest.zip
+			unzip -q wordpress-latest.zip
+			mv /wordpress/wordpress /wordpress/wordpress-nightly
+			rm -f wordpress-latest.zip
+			cd -
+		else
+			mkdir -p "/wordpress/wordpress-${VERSION}"
+			wget -q "https://wordpress.org/wordpress-${VERSION}.tar.gz" -O - | tar --strip-components=1 -zxm -f - -C "/wordpress/wordpress-${VERSION}"
+		fi
+		wget -q https://raw.github.com/markoheijnen/wp-mysqli/master/db.php -O "/wordpress/wordpress-${VERSION}/wp-content/db.php"
+	else
+		echo "Skipping WordPress download"
+	fi
+
+	if [ ! -d "/wordpress/wordpress-tests-lib-${VERSION}" ]; then
+		mkdir -p "/wordpress/wordpress-tests-lib-${VERSION}"
+		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}/tests/phpunit/includes/" "/wordpress/wordpress-tests-lib-${VERSION}/includes"
+		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}/tests/phpunit/data/" "/wordpress/wordpress-tests-lib-${VERSION}/data"
+		rm -f "/wordpress/wordpress-tests-lib-${VERSION}/wp-tests-config-sample.php"
+		wget -q "https://develop.svn.wordpress.org/${TESTS_TAG}/wp-tests-config-sample.php" -O "/wordpress/wordpress-tests-lib-${VERSION}/wp-tests-config-sample.php"
+	else
+		echo "Skipping WordPress test library download"
+	fi
+}
+
+download_wp "${1:-latest}"

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+set -x
+set -e
+
+: "${MYSQL_USER="wordpress"}"
+: "${MYSQL_PASSWORD="wordpress"}"
+: "${MYSQL_DB="wordpress_test"}"
+: "${MYSQL_HOST="db"}"
+: "${WP_VERSION:="latest"}"
+: "${PHPUNIT_VERSION:=""}"
+: "${PHP_VERSION:=""}"
+: "${DISABLE_XDEBUG:=""}"
+: "${APP_HOME:="/home/circleci/project"}"
+
+if [ ! -d "/wordpress/wordpress-${WP_VERSION}" ] || [ ! -d "/wordpress/wordpress-tests-lib-${WP_VERSION}" ]; then
+	install-wp "${WP_VERSION}"
+fi
+
+(
+	cd "/wordpress/wordpress-tests-lib-${WP_VERSION}" && \
+	cp -f wp-tests-config-sample.php wp-tests-config.php && \
+	sed -i "s/youremptytestdbnamehere/${MYSQL_DB}/; s/yourusernamehere/${MYSQL_USER}/; s/yourpasswordhere/${MYSQL_PASSWORD}/; s|localhost|${MYSQL_HOST}|" wp-tests-config.php && \
+	sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" wp-tests-config.php
+)
+
+rm -rf /tmp/wordpress /tmp/wordpress-tests-lib
+ln -sf "/wordpress/wordpress-${WP_VERSION}" /tmp/wordpress
+ln -sf "/wordpress/wordpress-tests-lib-${WP_VERSION}" /tmp/wordpress-tests-lib
+
+if [ -n "${PHP_VERSION}" ] && [ -x "/usr/bin/php${PHP_VERSION}" ]; then
+	sudo update-alternatives --set php "/usr/bin/php${PHP_VERSION}"
+fi
+
+if [ -n "${DISABLE_XDEBUG}" ]; then
+	PHPUNIT_ARGS="-d xdebug.mode=Off"
+else
+	PHPUNIT_ARGS=
+fi
+
+echo "Waiting for MySQL..."
+while ! nc -z "${MYSQL_HOST}" 3306; do
+	sleep 1
+done
+
+mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
+
+php -v
+
+if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; then
+	if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
+		PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
+	elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
+		PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
+	else
+		PHPUNIT=~/.composer/vendor/bin/phpunit
+	fi
+
+	"${PHPUNIT}" --version
+	echo "Running tests..."
+	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
+	"${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
+else
+	echo "Unable to find phpunit.xml or phpunit.xml.dist in ${APP_HOME}"
+	ls -lha "${APP_HOME}"
+	exit 1
+fi


### PR DESCRIPTION
This PR adds a new image to run CI tests for WordPress using CircleCI as the provider.

The image features:
* latest WP versions since WP 5.5 + trunk (updated daily)
* PHP 7.4, 8.0, 8.1
* PHPUnit 7, 8, 9 (latest versions)
* NodeJS 14, npm 6
* Subversion

The image is used in a test branch of [vip-go-mu-plugins](Automattic/vip-go-mu-plugins#2544). Its main advantages are that it reduces the CI time by providing all dependencies baked into the image and that it reduces the load on WP.org SVN (which sometimes rate-limits us).

Even though it is used by `vip-go-mu-plugins`, it can be used with any WP plugin (I use it myself for my plugins).
