### PR TITLE
Dependabot: monitor GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   # Enable version updates for Alpine
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` directory


### PR DESCRIPTION
This PR instructs Dependabot to monitor GitHub Actions and create PRs if they become outdated.
