### PR TITLE
Start cron control runner on php containers

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,4 +1,16 @@
+# 1) Build cron-control-runner
+FROM docker.io/library/golang:1.17.3 AS builder
+
+WORKDIR /cron-runner
+RUN git clone --depth 1 https://github.com/Automattic/cron-control-runner .
+RUN go mod download
+
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/cron-control-runner .
+
+# 2) Setup php container
 FROM php:7.4-fpm-alpine3.14
+
+WORKDIR /
 
 RUN apk update && \
     apk add --no-cache less bash mariadb-client gd shadow && \
@@ -23,6 +35,8 @@ COPY php-fpm/php.ini /usr/local/etc/php/php.ini
 
 # move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
 COPY php-fpm/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
+
+COPY --from=builder /cron-runner/bin/cron-control-runner /usr/local/bin/cron-control-runner
 
 COPY php-fpm/run.sh /usr/local/bin/run.sh
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,5 +1,4 @@
-# 1) Build cron-control-runner
-FROM docker.io/library/golang:1.17.3 AS builder
+FROM golang:1.17 AS builder
 
 WORKDIR /cron-runner
 RUN git clone --depth 1 https://github.com/Automattic/cron-control-runner .
@@ -7,7 +6,6 @@ RUN go mod download
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/cron-control-runner .
 
-# 2) Setup php container
 FROM php:7.4-fpm-alpine3.14
 
 WORKDIR /

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -16,6 +16,6 @@ fi
 
 # Kick off cron runner in a background process. Initial sleep is to help give WP time to be setup.
 echo "Starting cron runner"
-nohup bash -c 'sleep 60; /usr/local/bin/cron-control-runner -wp-path=/wp -wp-cli-path=/usr/local/bin/wp -get-sites-interval=120s -get-events-interval=60s -get-events-parallelism=1 -num-run-workers=2' &>/tmp/cron-runner.log &
+nohup bash -c 'sleep 60; /usr/local/bin/cron-control-runner -wp-path=/wp -wp-cli-path=/usr/local/bin/wp -get-sites-interval=120s -get-events-interval=60s -get-events-parallelism=1 -num-run-workers=2' &>/wp/log/cron-runner.log &
 
 php-fpm

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -16,6 +16,6 @@ fi
 
 # Kick off cron runner in a background process. Initial sleep is to help give WP time to be setup.
 echo "Starting cron runner"
-nohup bash -c 'sleep 60; /usr/local/bin/cron-control-runner -wp-path=/wp -wp-cli-path=/usr/local/bin/wp -get-sites-interval=120s -get-events-interval=60s' &>/tmp/cron-runner.log &
+nohup bash -c 'sleep 60; /usr/local/bin/cron-control-runner -wp-path=/wp -wp-cli-path=/usr/local/bin/wp -get-sites-interval=120s -get-events-interval=60s -get-events-parallelism=1 -num-run-workers=2' &>/tmp/cron-runner.log &
 
 php-fpm

--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -14,5 +14,8 @@ else
     fi
 fi
 
+# Kick off cron runner in a background process. Initial sleep is to help give WP time to be setup.
+echo "Starting cron runner"
+nohup bash -c 'sleep 60; /usr/local/bin/cron-control-runner -wp-path=/wp -wp-cli-path=/usr/local/bin/wp -get-sites-interval=120s -get-events-interval=60s' &>/tmp/cron-runner.log &
 
 php-fpm


### PR DESCRIPTION
Currently cron is not processed on dev-envs, as we set the `WPCOM_VIP_LOAD_CRON_CONTROL_LOCALLY` constant but never kick off the runner.

So this adds the cron runner to php containers in a background process. Using pretty conservative intervals, will only check for site changes every 120seconds and each site will get events to run every 60 seconds.

I tried to do this as a dev-tools script and w/ lando run, run_as_root, and various lando events. In each case, for an unknown reason, the background process would always disappear during dev-env's first boot-up. Subsequent stop/starts would work with some of them, but alas. This should be quite okay though, as we can pass lando-file / template-specific variables to the `run.sh` if needed.

## Testing

In the lando file, replace the php image with a local copy, like this:

```
  php:
    type: compose
    services:
      build:
        context: /Users/caleb/code/vip/platform/vip-container-images
        dockerfile: /Users/caleb/code/vip/platform/vip-container-images/php-fpm/Dockerfile
```

Then do `dev-env create`, `dev-env start`, etc. Once running, should see `Starting cron runner` in the php container logs. But then for further checking can `exec` into the container and see the process running with `ps`. Logs for the runner can be seen: `tail -f /tmp/cron-runner.log`. Logs should pretty quiet unless real errors happen. if you want to see more runner-related logs, you'll need to pass `-debug` to the cron-control-runner CLI.