### PR TITLE
Ignore group ID

### DIFF
--- a/dev-tools/scripts/user-container-setup.sh
+++ b/dev-tools/scripts/user-container-setup.sh
@@ -42,7 +42,7 @@ if [ "$LANDO_WEBROOT_UID" != "$LANDO_HOST_UID" ]; then
     cat /etc/group | grep -q "$LANDO_WEBROOT_GROUP"
     if [ $? != 0 ]; then
         lando_warn "Group $LANDO_WEBROOT_GROUP doesn't exist. Will attempt to create it."
-        groupadd --gid "$LANDO_HOST_GID" "$LANDO_WEBROOT_GROUP";
+        groupadd "$LANDO_WEBROOT_GROUP";
         if [ $? = 0 ]; then
             lando_info "SUCCESS: group added"
         else
@@ -58,4 +58,6 @@ if [ "$LANDO_WEBROOT_UID" != "$LANDO_HOST_UID" ]; then
         lando_error "User was not added"
         exit 1;
     fi
+
+    chown -R "$LANDO_WEBROOT_USER" "/home/$LANDO_WEBROOT_USER"
 fi


### PR DESCRIPTION
We don't strictly need `www-data` group to have host user's group ID. 

Trying to set the GID to some group that already exists break the execution. I tried to attempted to add the group with that specific ID and then without similar to what lando does, but there were some issues with `groupadd` not releasing file lock soon enough for the second run.

I also added a line that `chown`s the `www-data` home back after the id switch.   