### PR TITLE
Add support for PHP options

### DIFF
--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -48,8 +48,7 @@ done
 mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
 
 PHP="php ${PHP_OPTIONS}"
-
-php -v
+${PHP} -v
 
 if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; then
 	if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -12,6 +12,7 @@ set -e
 : "${PHP_VERSION:=""}"
 : "${DISABLE_XDEBUG:=""}"
 : "${APP_HOME:="/home/circleci/project"}"
+: "${PHP_OPTIONS:=""}"
 
 if [ ! -d "/wordpress/wordpress-${WP_VERSION}" ] || [ ! -d "/wordpress/wordpress-tests-lib-${WP_VERSION}" ]; then
 	install-wp "${WP_VERSION}"
@@ -33,6 +34,7 @@ if [ -n "${PHP_VERSION}" ] && [ -x "/usr/bin/php${PHP_VERSION}" ]; then
 fi
 
 if [ -n "${DISABLE_XDEBUG}" ]; then
+	PHP_OPTIONS="-d xdebug.mode=Off ${PHP_OPTIONS}"
 	PHPUNIT_ARGS="-d xdebug.mode=Off"
 else
 	PHPUNIT_ARGS=
@@ -45,6 +47,8 @@ done
 
 mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
 
+PHP="php ${PHP_OPTIONS}"
+
 php -v
 
 if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; then
@@ -56,10 +60,10 @@ if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; th
 		PHPUNIT=~/.composer/vendor/bin/phpunit
 	fi
 
-	"${PHPUNIT}" --version
+	${PHP} "${PHPUNIT}" --version
 	echo "Running tests..."
 	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
-	"${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
+	${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
 else
 	echo "Unable to find phpunit.xml or phpunit.xml.dist in ${APP_HOME}"
 	ls -lha "${APP_HOME}"


### PR DESCRIPTION
This PR adds support for PHP options to the test runner. This is useful for local development.

One of the use cases is to profile a slow test. You will need to pass some options to PHP, like `-d xdebug.mode=profile -d xdebug.output_dir=/home/circleci/project/tmp`. This PR allows to do that via `PHP_OPTIONS` environment variable.
