### PR TITLE
Do not run unnecessary builds

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "alpine/**"
+      - ".github/workflows/alpine.yml"
   pull_request:
+    paths:
+      - "alpine/**"
+      - ".github/workflows/alpine.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "dev-tools/**"
+      - ".github/workflows/dev-tools.yml"
   pull_request:
+    paths:
+      - "dev-tools/**"
+      - ".github/workflows/dev-tools.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/mu-plugins.yml
+++ b/.github/workflows/mu-plugins.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "mu-plugins/**"
+      - ".github/workflows/mu-plugins.yml"
   pull_request:
+    paths:
+      - "mu-plugins/**"
+      - ".github/workflows/mu-plugins.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "nginx/**"
+      - ".github/workflows/nginx.yml"
   pull_request:
+    paths:
+      - "nginx/**"
+      - ".github/workflows/nginx.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "php-fpm/**"
+      - ".github/workflows/php-fpm.yml"
   pull_request:
+    paths:
+      - "php-fpm/**"
+      - ".github/workflows/php-fpm.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "skeleton/**"
+      - ".github/workflows/skeleton.yml"
   pull_request:
+    paths:
+      - "skeleton/**"
+      - ".github/workflows/skeleton.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "statsd/**"
+      - ".github/workflows/statsd.yml"
   pull_request:
+    paths:
+      - "statsd/**"
+      - ".github/workflows/statsd.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "traefik/**"
+      - ".github/workflows/traefik.yml"
   pull_request:
+    paths:
+      - "traefik/**"
+      - ".github/workflows/traefik.yml"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "wordpress/**"
+      - ".github/workflows/wordpress.yml"
   pull_request:
+    paths:
+      - "wordpress/**"
+      - ".github/workflows/wordpress.yml"
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
This PR updates the workflows so that the image is built only if there are modifications to its files or its workflow.

This allows us not to waste time (re)building images with no changes.
