### PR TITLE
Update php-fpm image

### DIFF
--- a/php-fpm/run.sh
+++ b/php-fpm/run.sh
@@ -1,8 +1,9 @@
-#! /bin/bash
+#!/bin/sh
+
 XDEBUG_CONFIG_TEMPLATE_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
 XDEBUG_CONFIG_TARGET_LOCATION=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-if [ "enable" == "$XDEBUG" ]; then
+if [ "enable" = "$XDEBUG" ]; then
     echo "Enabling XDebug"
 
     cp $XDEBUG_CONFIG_TEMPLATE_LOCATION $XDEBUG_CONFIG_TARGET_LOCATION
@@ -14,5 +15,4 @@ else
     fi
 fi
 
-
-php-fpm
+exec php-fpm


### PR DESCRIPTION
* Switch `run.sh` to `sh` from `bash` — `sh` is built into `busybox` in Alpine, and consumes much less resources than `bash`;
* Add `exec` to `php-fpm` to replace the current shell with `php-fpm` and save a bit of RAM.
