### PR TITLE
Add MariaDB-Lite image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,8 @@ updates:
     directory: "wp-test-runner/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "mariadb-lite/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/mariadb-lite.yml
+++ b/.github/workflows/mariadb-lite.yml
@@ -1,0 +1,48 @@
+name: Build MariaDB Lite Image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "mariadb-lite/**"
+      - ".github/workflows/mariadb-lite.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "mariadb-lite/**"
+      - ".github/workflows/mariadb-lite.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Get image version
+        id: getversion
+        run: |
+          echo "::set-output name=version::$(awk -F: '/^FROM / {print $2}' mariadb-lite/Dockerfile)"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: mariadb-lite
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/automattic/vip-container-images/mariadb-lite:${{ steps.getversion.outputs.version }}

--- a/mariadb-lite/Dockerfile
+++ b/mariadb-lite/Dockerfile
@@ -1,0 +1,9 @@
+FROM mariadb:10.3
+
+RUN \
+    apt-get -qq update && \
+    apt-get -qq install eatmydata && \
+    eatmydata apt-get -qq upgrade && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LD_PRELOAD libeatmydata.so

--- a/mariadb-lite/Dockerfile
+++ b/mariadb-lite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.3
+FROM circleci/mariadb:10.3
 
 RUN \
     apt-get -qq update && \


### PR DESCRIPTION
This image is a combination of `eatmydata` and the classic MariaDB image. It is good to be used for unit tests because it is faster than the traditional image. However, it is **not safe** to be used in production because it does not care about the data — any crash can damage the database beyond any repair. It is OK for tests, because the database lives in a throwaway container.

I am going to write a P2 explaining how this works.