### PR TITLE
Update WP Test Runner

### DIFF
--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 	eatmydata apt-get -qq upgrade && \
 	eatmydata apt-get -qq install php7.4 php7.4-apcu php7.4-curl php7.4-gd php7.4-gmp php7.4-igbinary php7.4-imagick php7.4-imap php7.4-intl php7.4-mbstring php7.4-mysql php7.4-sqlite3 php7.4-xdebug php7.4-xml php7.4-xsl php7.4-zip && \
 	eatmydata apt-get -qq install php8.0 php8.0-apcu php8.0-curl php8.0-gd php8.0-gmp php8.0-igbinary php8.0-imagick php8.0-imap php8.0-intl php8.0-mbstring php8.0-mysql php8.0-sqlite3 php8.0-xdebug php8.0-xml php8.0-xsl php8.0-zip && \
-	eatmydata apt-get -qq install php8.1 php8.1-curl php8.1-gd php8.1-gmp php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xml php8.1-zip && \
+	eatmydata apt-get -qq install php8.1 php8.1-apcu php8.1-curl php8.1-gd php8.1-gmp php8.1-igbinary php8.1-imagick php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xdebug php8.1-xml php8.1-zip && \
 	eatmydata apt-get -qq install subversion unzip default-mysql-client nodejs npm && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	echo "xdebug.mode=coverage" | tee /etc/php/*/mods-available/xdebug.ini && \
@@ -34,7 +34,8 @@ ENV LD_PRELOAD libeatmydata.so
 RUN composer global require phpunit/phpunit:^7 yoast/phpunit-polyfills:^1
 
 RUN \
-	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]') latest; do \
+	WP_VERSIONS=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]'); \
+	for version in ${WP_VERSIONS} latest; do \
 		install-wp "${version}" & \
 	done && \
 	wait
@@ -43,6 +44,7 @@ RUN install-wp nightly
 
 USER root
 COPY runner.sh /usr/local/bin/runner
+COPY configure-environment.sh /usr/local/bin/configure-environment
 ENTRYPOINT ["/usr/local/bin/runner"]
 
 USER circleci

--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -43,8 +43,9 @@ RUN \
 RUN install-wp nightly
 
 USER root
-COPY runner.sh /usr/local/bin/runner
 COPY configure-environment.sh /usr/local/bin/configure-environment
+COPY create-database.sh /usr/local/bin/create-database
+COPY runner.sh /usr/local/bin/runner
 ENTRYPOINT ["/usr/local/bin/runner"]
 
 USER circleci

--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -30,7 +30,7 @@ COPY install-wp.sh /usr/local/bin/install-wp
 
 USER circleci
 
-ENV LD_PRELOAD libeatmydata.so
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
 RUN composer global require phpunit/phpunit:^7 yoast/phpunit-polyfills:^1
 
 RUN \

--- a/wp-test-runner/configure-environment.sh
+++ b/wp-test-runner/configure-environment.sh
@@ -43,13 +43,6 @@ else
     echo 'XDebug enabled'
 fi
 
-echo "Waiting for MySQL..."
-while ! nc -z "${MYSQL_HOST}" 3306; do
-	sleep 1
-done
-
-mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
-
 PHP="php ${PHP_OPTIONS}"
 
 if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then

--- a/wp-test-runner/configure-environment.sh
+++ b/wp-test-runner/configure-environment.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+: "${MYSQL_USER="wordpress"}"
+: "${MYSQL_PASSWORD="wordpress"}"
+: "${MYSQL_DB="wordpress_test"}"
+: "${MYSQL_HOST="db"}"
+: "${WP_VERSION:="latest"}"
+: "${PHPUNIT_VERSION:=""}"
+: "${PHP_VERSION:="7.4"}"
+: "${DISABLE_XDEBUG:=""}"
+: "${APP_HOME:="/home/circleci/project"}"
+: "${PHP_OPTIONS:=""}"
+
+if [ ! -d "/wordpress/wordpress-${WP_VERSION}" ] || [ ! -d "/wordpress/wordpress-tests-lib-${WP_VERSION}" ]; then
+	install-wp "${WP_VERSION}"
+fi
+
+(
+	cd "/wordpress/wordpress-tests-lib-${WP_VERSION}" && \
+	cp -f wp-tests-config-sample.php wp-tests-config.php && \
+	sed -i "s/youremptytestdbnamehere/${MYSQL_DB}/; s/yourusernamehere/${MYSQL_USER}/; s/yourpasswordhere/${MYSQL_PASSWORD}/; s|localhost|${MYSQL_HOST}|" wp-tests-config.php && \
+	sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" wp-tests-config.php
+)
+
+rm -rf /tmp/wordpress /tmp/wordpress-tests-lib
+ln -sf "/wordpress/wordpress-${WP_VERSION}" /tmp/wordpress
+ln -sf "/wordpress/wordpress-tests-lib-${WP_VERSION}" /tmp/wordpress-tests-lib
+
+if [ -x "/usr/bin/php${PHP_VERSION}" ]; then
+	sudo update-alternatives --set php "/usr/bin/php${PHP_VERSION}"
+else
+	echo "Unsupported PHP version: ${PHP_VERSION}"
+	exit 1
+fi
+
+if [ -n "${DISABLE_XDEBUG}" ]; then
+	sudo phpdismod -v "${PHP_VERSION}" xdebug || true
+    echo 'XDebug disabled'
+else
+	sudo phpenmod -v "${PHP_VERSION}" xdebug || true
+    echo 'XDebug enabled'
+fi
+
+echo "Waiting for MySQL..."
+while ! nc -z "${MYSQL_HOST}" 3306; do
+	sleep 1
+done
+
+mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
+
+PHP="php ${PHP_OPTIONS}"
+
+if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
+    PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
+elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
+    PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
+else
+    PHPUNIT=~/.composer/vendor/bin/phpunit
+fi
+
+echo "WordPress version: ${WP_VERSION}"
+echo "Working directory: ${APP_HOME}"
+echo "PHPUnit executable: ${PHPUNIT}"
+
+${PHP} -v
+${PHP} "${PHPUNIT}" --version

--- a/wp-test-runner/create-database.sh
+++ b/wp-test-runner/create-database.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+DB_USER="${1:-${MYSQL_USER}}"
+DB_PASSWORD="${2:-${MYSQL_PASSWORD}}"
+DB_NAME="${3:-${MYSQL_DB}}"
+DB_HOST="${4:-${MYSQL_HOST}}"
+
+echo "Waiting for MySQL..."
+while ! nc -z "${DB_HOST}" 3306; do
+	sleep 1
+done
+
+mysqladmin create "${DB_NAME}" --user="${DB_USER}" --password="${DB_PASSWORD}" --host="${DB_HOST}" || true

--- a/wp-test-runner/install-wp.sh
+++ b/wp-test-runner/install-wp.sh
@@ -13,7 +13,11 @@ download_wp() {
 			echo "Unable to detect the latest WP version"
 			exit 1
 		fi
-		TESTS_TAG="tags/${LATEST}"
+
+		download_wp "${LATEST}"
+		ln -sf "/wordpress/wordpress-${LATEST}" /wordpress/wordpress-latest
+		ln -sf "/wordpress/wordpress-tests-lib-${LATEST}" /wordpress/wordpress-tests-lib-latest
+		return
 	else
 		TESTS_TAG="tags/${VERSION}"
 	fi

--- a/wp-test-runner/install-wp.sh
+++ b/wp-test-runner/install-wp.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 
-set -x
 set -e
 
 download_wp() {
 	VERSION="$1"
-	if [ "${VERSION}" = "nightly" ]; then
+	if [ "${VERSION}" = "nightly" ] || [ "${VERSION}" = "trunk" ]; then
 		TESTS_TAG="trunk"
 	elif [ "${VERSION}" = "latest" ]; then
 		VERSIONS=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - )

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -3,27 +3,27 @@
 set -e
 
 configure-environment
+create-database
 
 : "${PHP_OPTIONS:=""}"
 : "${PHPUNIT_VERSION:=""}"
 : "${APP_HOME:="/home/circleci/project"}"
+: "${PRETEST_SCRIPT:=""}"
 
 PHP="php ${PHP_OPTIONS}"
 
-if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; then
-	if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
-		PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
-	elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
-		PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
-	else
-		PHPUNIT=~/.composer/vendor/bin/phpunit
-	fi
-
-	echo "Running tests..."
-	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
-	${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
+if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
+	PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
+elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
+	PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
 else
-	echo "Unable to find phpunit.xml or phpunit.xml.dist in ${APP_HOME}"
-	ls -lha "${APP_HOME}"
-	exit 1
+	PHPUNIT=~/.composer/vendor/bin/phpunit
 fi
+
+if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
+	"${PRETEST_SCRIPT}"
+fi
+
+echo "Running tests..."
+# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
+${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -1,56 +1,14 @@
 #!/bin/sh
 
-set -x
 set -e
 
-: "${MYSQL_USER="wordpress"}"
-: "${MYSQL_PASSWORD="wordpress"}"
-: "${MYSQL_DB="wordpress_test"}"
-: "${MYSQL_HOST="db"}"
-: "${WP_VERSION:="latest"}"
-: "${PHPUNIT_VERSION:=""}"
-: "${PHP_VERSION:="7.4"}"
-: "${DISABLE_XDEBUG:=""}"
-: "${APP_HOME:="/home/circleci/project"}"
+configure-environment
+
 : "${PHP_OPTIONS:=""}"
-
-if [ ! -d "/wordpress/wordpress-${WP_VERSION}" ] || [ ! -d "/wordpress/wordpress-tests-lib-${WP_VERSION}" ]; then
-	install-wp "${WP_VERSION}"
-fi
-
-(
-	cd "/wordpress/wordpress-tests-lib-${WP_VERSION}" && \
-	cp -f wp-tests-config-sample.php wp-tests-config.php && \
-	sed -i "s/youremptytestdbnamehere/${MYSQL_DB}/; s/yourusernamehere/${MYSQL_USER}/; s/yourpasswordhere/${MYSQL_PASSWORD}/; s|localhost|${MYSQL_HOST}|" wp-tests-config.php && \
-	sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" wp-tests-config.php
-)
-
-rm -rf /tmp/wordpress /tmp/wordpress-tests-lib
-ln -sf "/wordpress/wordpress-${WP_VERSION}" /tmp/wordpress
-ln -sf "/wordpress/wordpress-tests-lib-${WP_VERSION}" /tmp/wordpress-tests-lib
-
-if [ -x "/usr/bin/php${PHP_VERSION}" ]; then
-	sudo update-alternatives --set php "/usr/bin/php${PHP_VERSION}"
-else
-	echo "Unsupported PHP version: ${PHP_VERSION}"
-	exit 1
-fi
-
-if [ -n "${DISABLE_XDEBUG}" ]; then
-	sudo phpdismod -v "${PHP_VERSION}" xdebug || true
-else
-	sudo phpenmod -v "${PHP_VERSION}" xdebug || true
-fi
-
-echo "Waiting for MySQL..."
-while ! nc -z "${MYSQL_HOST}" 3306; do
-	sleep 1
-done
-
-mysqladmin create "${MYSQL_DB}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --host="${MYSQL_HOST}" || true
+: "${PHPUNIT_VERSION:=""}"
+: "${APP_HOME:="/home/circleci/project"}"
 
 PHP="php ${PHP_OPTIONS}"
-${PHP} -v
 
 if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; then
 	if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
@@ -61,7 +19,6 @@ if [ -f "${APP_HOME}/phpunit.xml" ] || [ -f "${APP_HOME}/phpunit.xml.dist" ]; th
 		PHPUNIT=~/.composer/vendor/bin/phpunit
 	fi
 
-	${PHP} "${PHPUNIT}" --version
 	echo "Running tests..."
 	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
 	${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"


### PR DESCRIPTION
  * Move environment initialization code into `configure-environment` (this makes it easier to debug failed tests directly in the container);
  * Add missing PHP 8.1 packages;
  * Make test runner less verbose;
  * Do not require `phpunit.xml` or `phpunit.xml.dist`;
  * Add support for a pre-test script (will be run prior to PHPUnit in case some additional configuration is required).

