### PR TITLE
Add WP Core Test Runner image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,11 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    directory: "wp-core-test-runner/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
     directory: "mariadb-lite/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/wp-core-test-runner.yml
+++ b/.github/workflows/wp-core-test-runner.yml
@@ -1,0 +1,51 @@
+name: Build WP Core Test Runner image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "wp-core-test-runner/**"
+      - ".github/workflows/wp-core-test-runner.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "wp-core-test-runner/**"
+      - ".github/workflows/wp-core-test-runner.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Set up Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ghcr.io/automattic/vip-container-images/wp-core-test-runner
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: wp-core-test-runner
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -22,7 +22,11 @@ ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
 USER circleci
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR /home/circleci/.nvm
-RUN install-wp-core latest
+
+RUN \
+	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]') latest; do \
+		install-wp-core "${version}"; \
+	done
 
 USER root
 COPY configure-environment.sh /usr/local/bin/configure-environment

--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -1,0 +1,33 @@
+FROM cimg/base:stable-20.04
+
+USER root
+
+RUN \
+	export DEBIAN_FRONTEND=noninteractive; \
+	echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+	apt-get -qq update && apt-get -qq install eatmydata && \
+	add-apt-repository -y ppa:ondrej/php && \
+	eatmydata apt-get -qq upgrade && \
+	eatmydata apt-get -qq install php7.4 php7.4-apcu php7.4-curl php7.4-gd php7.4-gmp php7.4-igbinary php7.4-imagick php7.4-imap php7.4-intl php7.4-mbstring php7.4-mysql php7.4-sqlite3 php7.4-xdebug php7.4-xml php7.4-xsl php7.4-zip && \
+	eatmydata apt-get -qq install subversion unzip default-mysql-client && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN \
+	install -d -o circleci -g circleci -m 0777 /wordpress && \
+	wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/bin/ --filename=composer
+
+COPY install-wp-core.sh /usr/local/bin/install-wp-core
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
+
+USER circleci
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+ENV NVM_DIR /home/circleci/.nvm
+RUN install-wp-core latest
+
+USER root
+COPY configure-environment.sh /usr/local/bin/configure-environment
+COPY create-database.sh /usr/local/bin/create-database
+COPY runner.sh /usr/local/bin/runner
+ENTRYPOINT ["/usr/local/bin/runner"]
+
+USER circleci

--- a/wp-core-test-runner/configure-environment.sh
+++ b/wp-core-test-runner/configure-environment.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+: "${MYSQL_USER="wordpress"}"
+: "${MYSQL_PASSWORD="wordpress"}"
+: "${MYSQL_DB="wordpress_test"}"
+: "${MYSQL_HOST="db"}"
+: "${WP_VERSION:="latest"}"
+
+if [ ! -d "/wordpress/wordpress-core-${WP_VERSION}" ]; then
+	install-wp-core "${WP_VERSION}"
+fi
+
+rm -f "${HOME}/wordpress-core" || true
+ln -sf "/wordpress/wordpress-core-${WP_VERSION}" "${HOME}/wordpress-core"
+sed \
+	"s/youremptytestdbnamehere/${MYSQL_DB}/; s/yourusernamehere/${MYSQL_USER}/; s/yourpasswordhere/${MYSQL_PASSWORD}/; s|localhost|${MYSQL_HOST}|" \
+	"${HOME}/wordpress-core/wp-tests-config-sample.php" \
+	> "${HOME}/wordpress-core/wp-tests-config.php"

--- a/wp-core-test-runner/create-database.sh
+++ b/wp-core-test-runner/create-database.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+DB_USER="${1:-${MYSQL_USER}}"
+DB_PASSWORD="${2:-${MYSQL_PASSWORD}}"
+DB_NAME="${3:-${MYSQL_DB}}"
+DB_HOST="${4:-${MYSQL_HOST}}"
+
+echo "Waiting for MySQL..."
+while ! nc -z "${DB_HOST}" 3306; do
+	sleep 1
+done
+
+mysqladmin create "${DB_NAME}" --user="${DB_USER}" --password="${DB_PASSWORD}" --host="${DB_HOST}" || true

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+download_wp_core() {
+	VERSION="$1"
+	if [ "${VERSION}" = "nightly" ] || [ "${VERSION}" = "trunk" ]; then
+		TESTS_TAG="trunk"
+	elif [ "${VERSION}" = "latest" ]; then
+		VERSIONS=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - )
+		LATEST=$(echo "${VERSIONS}" | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')
+		if [ -z "${LATEST}" ]; then
+			echo "Unable to detect the latest WP version"
+			exit 1
+		fi
+		TESTS_TAG="tags/${LATEST}"
+	else
+		TESTS_TAG="tags/${VERSION}"
+	fi
+
+	if [ ! -d "/wordpress/wordpress-core-${VERSION}" ]; then
+		mkdir -p "/wordpress/wordpress-core-${VERSION}"
+		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}" "/wordpress/wordpress-core-${VERSION}"
+		(
+			cd "/wordpress/wordpress-core-${VERSION}" && \
+			composer install -n && \
+			nvm install && \
+			nvm use && \
+			npm ci && \
+			npm run build
+		)
+	else
+		echo "Skipping WordPress download"
+	fi
+}
+
+# shellcheck disable=SC1091
+[ -f "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+download_wp_core "${1:-latest}"

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -13,7 +13,10 @@ download_wp_core() {
 			echo "Unable to detect the latest WP version"
 			exit 1
 		fi
-		TESTS_TAG="tags/${LATEST}"
+
+		download_wp_core "${LATEST}"
+		ln -sf "/wordpress/wordpress-core-${LATEST}" /wordpress/wordpress-core-latest
+		return
 	else
 		TESTS_TAG="tags/${VERSION}"
 	fi

--- a/wp-core-test-runner/runner.sh
+++ b/wp-core-test-runner/runner.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+configure-environment
+create-database
+
+: "${PHP_OPTIONS:=""}"
+: "${WP_MULTISITE:=""}"
+: "${WP_VERSION:="latest"}"
+: "${PRETEST_SCRIPT:=""}"
+
+PHP="php ${PHP_OPTIONS}"
+PHPUNIT_ARGS=
+
+if [ "1" = "${WP_MULTISITE}" ]; then
+	PHPUNIT_ARGS="-c tests/phpunit/multisite.xml"
+fi
+
+if [ "${WP_VERSION}" != "nightly" ] && [ "${WP_VERSION}" != "trunk" ]; then
+	export GITHUB_EVENT_NAME=pull_request
+fi
+
+if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
+	"${PRETEST_SCRIPT}"
+fi
+
+#shellcheck disable=SC2086
+cd "${HOME}/wordpress-core/" && ${PHP} "${HOME}/wordpress-core/vendor/bin/phpunit" ${PHPUNIT_ARGS}

--- a/wp-core-test-runner/runner.sh
+++ b/wp-core-test-runner/runner.sh
@@ -25,5 +25,5 @@ if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
 	"${PRETEST_SCRIPT}"
 fi
 
-#shellcheck disable=SC2086
+# shellcheck disable=SC2086
 cd "${HOME}/wordpress-core/" && ${PHP} "${HOME}/wordpress-core/vendor/bin/phpunit" ${PHPUNIT_ARGS}


### PR DESCRIPTION
This image is similar to WP Test Runner. Its purpose is to run WP Core tests.

Currently, in CI, we spent the most time building the WP Core. This image has the core pre-built.

**How to test locally**

Set up the database container:
```bash
docker network create wptest
docker run -d --rm --network wptest --name mysql \
    -e MYSQL_ROOT_PASSWORD=wordpress \
    -e MARIADB_INITDB_SKIP_TZINFO=1 \
    -e MYSQL_USER=wordpress \
    -e MYSQL_PASSWORD=wordpress \
    -e MYSQL_DATABASE=wordpress_test \
    --tmpfs /var/lib/mysql \
    ghcr.io/automattic/vip-container-images/mariadb-lite:10.3
```

Run this from `vip-go-mu-plugins` directory (adjust the image name as necessary):
```bash
docker run -it --rm --network wptest \
    -e MYSQL_HOST=mysql \
    -e WP_MULTISITE=1 \
    -v $(pwd):/wordpress/wordpress-core-latest/build/wp-content/mu-plugins \
    wp-core-test-runner
```

For single-site mode, remove `-e WP_MULTISITE=1`.

Note there is no need to exclude tests nor run them in the isolated mode.