### PR TITLE
Update WP Core Test Runner

### DIFF
--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -25,7 +25,7 @@ ENV NVM_DIR /home/circleci/.nvm
 
 RUN \
 	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]') latest; do \
-		install-wp-core "${version}"; \
+		DOCKER_BUILD=1 install-wp-core "${version}"; \
 	done
 
 USER root

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -24,6 +24,7 @@ download_wp_core() {
 	if [ ! -d "/wordpress/wordpress-core-${VERSION}" ]; then
 		mkdir -p "/wordpress/wordpress-core-${VERSION}"
 		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}" "/wordpress/wordpress-core-${VERSION}"
+		svn co --quiet https://plugins.svn.wordpress.org/wordpress-importer/trunk/ "/wordpress/wordpress-core-${WP_VERSION}/tests/phpunit/data/plugins/wordpress-importer"
 		(
 			cd "/wordpress/wordpress-core-${VERSION}" && \
 			composer install -n && \

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -32,6 +32,10 @@ download_wp_core() {
 			nvm use && \
 			npm ci && \
 			npm run build
+
+			if [ -n "${DOCKER_BUILD}" ]; then
+				rm -rf node_modules .svn src
+			fi
 		)
 	else
 		echo "Skipping WordPress download"


### PR DESCRIPTION
* Bake WP Importer into the image
* Reduce image size by removing directories not used during tests (node_modules, src, .svn)
