### PR TITLE
Added nginx conf support for multisites running in subdirectories mode

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -19,6 +19,13 @@ server {
 
   include /etc/nginx/conf.extra/*.conf;
 
+  # Support multisites in subdirectories mode. 
+  # ie: local.vipdev.lndo.site/subsite1/wp-admin/ should be rewritten to /wp-admin/ folder.
+  if (!-e $request_filename) {
+    rewrite ^(/[^/]+)?(/wp-.*) $2 last;
+    rewrite ^(/[^/]+)?(/.*\.php) $2 last;
+  }
+
   location = /favicon.ico {
     log_not_found off;
     access_log off;


### PR DESCRIPTION
Add support for multisites running in [subdirectories mode](https://wordpress.org/support/article/create-a-network/#step-0-before-you-begin). 
With this change, now these two alternatives will work:
- http://subsite1.local.vipdev.lndo.site/
- http://local.vipdev.lndo.site/subsite1/

This PR was tested by adding the modification to the file extra.conf. 