### PR TITLE
WordPress Images new properties: "locked" and "prerelease"

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -2,61 +2,85 @@
     {
         "ref": "5.5",
         "tag": "5.5",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.6",
         "tag": "5.6",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.7",
         "tag": "5.7",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.7.2",
         "tag": "5.7.2",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.7.3",
         "tag": "5.7.3",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.7.4",
         "tag": "5.7.4",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.7.5",
         "tag": "5.7.5",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.8",
         "tag": "5.8",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.8.1",
         "tag": "5.8.1",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.8.2",
         "tag": "5.8.2",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
         "ref": "5.8.3",
         "tag": "5.8.3",
-        "cacheable": true
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     },
     {
-        "ref": "5.9-branch",
+        "ref": "5.9",
         "tag": "5.9",
-        "cacheable": false
+        "cacheable": true,
+        "locked": false,
+        "prerelease": false
     }
 ]


### PR DESCRIPTION
"Locked" will support one-off images that don't get removed.
"Prerelease" will signal to the user that the image is not stable.