### PR TITLE
Update the dev-environment WordPress images, metadata and scripts

### DIFF
--- a/wordpress/add-version.sh
+++ b/wordpress/add-version.sh
@@ -2,16 +2,16 @@
 
 if [ $# -lt 2 ]; then
     echo "Usage: add-version.sh <gitref> <tag> [cacheable]"
-    echo "  - <gitref>:     changeset/tag to import from the WordPress git repository"
     echo "  - <tag>:        tag for the resulting Docker image"
+    echo "  - <gitref>:     changeset/tag to import from the WordPress git repository"
     echo "  - <cacheable>:  optional parameter; if not empty, the ref will be marked as eligible for caching"
     echo "  - <locked>:     tag the image that it should be locked from automated curation"
     echo "  - <prerelease>: marks the image as using an unstable ref"
     exit 1
 fi
 
-REF="$1"
-TAG="$2"
+TAG="$1"
+REF="$2"
 
 if [ -n "$3" ]; then
     CACHEABLE=true
@@ -20,22 +20,22 @@ else
 fi
 
 if [ -n "$4" ]; then
-    LOCKED=false
-else
     LOCKED=true
+else
+    LOCKED=false
 fi
 
 if [ -n "$5" ]; then
-    PRERELEASE=false
-else
     PRERELEASE=true
+else
+    PRERELEASE=false
 fi
 
 VERSIONS="$(dirname "$0")/versions.json"
 
-exists=$(jq -r ".[] | select(.ref == \"${REF}\") | .ref" "${VERSIONS}")
+exists=$(jq -r ".[] | select(.tag == \"${TAG}\") | .ref" "${VERSIONS}")
 if [ -z "${exists}" ]; then
     jq ". += [{ref: \"${REF}\", tag: \"${TAG}\", cacheable: ${CACHEABLE}, locked: ${LOCKED}, prerelease: ${PRERELEASE} }] | sort" "${VERSIONS}" | sponge "${VERSIONS}"
 else
-    echo "${REF} already exists in versions.json"
+    echo "${TAG} already exists in versions.json"
 fi

--- a/wordpress/add-version.sh
+++ b/wordpress/add-version.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if [ $# -lt 2 ]; then
-    echo "Usage: add-version.sh <gitref> <tag> [cacheable]"
+    echo "Usage: add-version.sh <tag> <gitref> [cacheable] [locked] [prerelease]"
     echo "  - <tag>:        tag for the resulting Docker image"
     echo "  - <gitref>:     changeset/tag to import from the WordPress git repository"
-    echo "  - <cacheable>:  optional parameter; if not empty, the ref will be marked as eligible for caching"
-    echo "  - <locked>:     tag the image that it should be locked from automated curation"
-    echo "  - <prerelease>: marks the image as using an unstable ref"
+    echo "  - [cacheable]:  optional parameter; if not empty, the ref will be marked as eligible for caching"
+    echo "  - [locked]:     tag the image that it should be locked from automated curation"
+    echo "  - [prerelease]: marks the image as using an unstable ref"
     exit 1
 fi
 

--- a/wordpress/del-version.sh
+++ b/wordpress/del-version.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
 if [ $# -lt 1 ]; then
-    echo "Usage: del-version.sh <gitref>"
-    echo "  - <gitref>: changeset/tag from the WordPress git repository"
+    echo "Usage: del-version.sh <tag>"
+    echo "  - <tag>: changeset/tag from the WordPress git repository"
     exit 1
 fi
 
-exists=$(jq -r ".[] | select(.ref == \"${REF}\") | .ref" "${VERSIONS}")
+TAG="$1"
+
+VERSIONS="$(dirname "$0")/versions.json"
+
+exists=$(jq -r ".[] | select(.tag == \"${TAG}\") | .ref" "${VERSIONS}")
 if [ -n "${exists}" ]; then
-    jq "del(.[] | select(.ref == \"${REF}\"))" "${VERSIONS}" | sponge "${VERSIONS}"
+    jq "del(.[] | select(.tag == \"${TAG}\"))" "${VERSIONS}" | sponge "${VERSIONS}"
 else
     echo "${REF} does not exist in versions.json"
 fi

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,86 +1,93 @@
 [
-    {
-        "ref": "5.5",
-        "tag": "5.5",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.6",
-        "tag": "5.6",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.7",
-        "tag": "5.7",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.7.2",
-        "tag": "5.7.2",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.7.3",
-        "tag": "5.7.3",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.7.4",
-        "tag": "5.7.4",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.7.5",
-        "tag": "5.7.5",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.8",
-        "tag": "5.8",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.8.1",
-        "tag": "5.8.1",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.8.2",
-        "tag": "5.8.2",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.8.3",
-        "tag": "5.8.3",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    },
-    {
-        "ref": "5.9",
-        "tag": "5.9",
-        "cacheable": true,
-        "locked": false,
-        "prerelease": false
-    }
+  {
+    "ref": "5.7.2",
+    "tag": "5.7.2",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.7.3",
+    "tag": "5.7.3",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.7.4",
+    "tag": "5.7.4",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.7.5",
+    "tag": "5.7.5",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.8",
+    "tag": "5.8",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.8.1",
+    "tag": "5.8.1",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.8.2",
+    "tag": "5.8.2",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.8.3",
+    "tag": "5.8.3",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
+  },
+  {
+    "ref": "5.9",
+    "tag": "5.9",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": false
+  },
+  {
+    "ref": "5.5.8",
+    "tag": "5.5",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
+  },
+  {
+    "ref": "5.6.7",
+    "tag": "5.6",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
+  },
+  {
+    "ref": "5.7.5",
+    "tag": "5.7",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
+  },
+  {
+    "ref": "3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74",
+    "tag": "5.9.1",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": true
+  }
 ]


### PR DESCRIPTION
* Changes to wordpress/versions.json to update the dev-environment images and metadata
* On wordpress/add-version.sh I swapped the argument order so that the "tag" argument is the first argument
* Fixed an error with the assignment of locked and prerelease arguments
* Changed wordpress/add-version.sh so that it tries to match by tag instead of ref.
  * The reason why I make this change is because I want to make an image of 5.7 that has a ref of 5.7.5, an image that already exists
  * I want to make each line distinct by tag instead of ref
* Changed wordpress/del-version.sh so that it deletes by tag instead of ref, to be consistent with the changes in wordpress/add-version.sh