### PR TITLE
Bug fixes for WP Test Runner

### DIFF
--- a/wp-test-runner/configure-environment.sh
+++ b/wp-test-runner/configure-environment.sh
@@ -49,8 +49,10 @@ if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
     PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
 elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
     PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
+elif [ -x "${APP_HOME}/vendor/bin/phpunit" ]; then
+	PHPUNIT=~/.composer/vendor/bin/phpunit
 else
-    PHPUNIT=~/.composer/vendor/bin/phpunit
+	PHPUNIT=/usr/local/bin/phpunit7
 fi
 
 echo "WordPress version: ${WP_VERSION}"
@@ -59,3 +61,6 @@ echo "PHPUnit executable: ${PHPUNIT}"
 
 ${PHP} -v
 ${PHP} "${PHPUNIT}" --version
+
+export PHP
+export PHPUNIT

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -2,22 +2,17 @@
 
 set -e
 
-configure-environment
-create-database
+. configure-environment
+. create-database
 
 : "${PHP_OPTIONS:=""}"
 : "${PHPUNIT_VERSION:=""}"
 : "${APP_HOME:="/home/circleci/project"}"
 : "${PRETEST_SCRIPT:=""}"
 
-PHP="php ${PHP_OPTIONS}"
-
-if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
-	PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
-elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
-	PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
-else
-	PHPUNIT=~/.composer/vendor/bin/phpunit
+if [ ! -d "${APP_HOME}/vendor/yoast/phpunit-polyfills" ]; then
+	WP_TESTS_PHPUNIT_POLYFILLS_PATH="$(composer config -g home)/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php"
+	PHP="${PHP} -d auto_prepend_file=${WP_TESTS_PHPUNIT_POLYFILLS_PATH}"
 fi
 
 if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then


### PR DESCRIPTION
  * Fall back to PHPUnit 7 if `vendor/bin/phpunit` does not exist or is not executable;
  * Use the bundled copy of Yoast PHPUnit Polyfills if the app under test does not have its own copy;
  * Deduplicate code
