### PR TITLE
Change fastcgi values to a higher value

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -56,8 +56,8 @@ server {
     include fastcgi_params;
     fastcgi_intercept_errors on;
     fastcgi_pass php:9000;
-    fastcgi_buffers 128 4096k;
-    fastcgi_buffer_size 4096k;
+    fastcgi_buffers 256 4k;
+    fastcgi_buffer_size 48k;
     fastcgi_connect_timeout 3000s;
     fastcgi_send_timeout 3000s;
     fastcgi_read_timeout 3000s;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -56,8 +56,8 @@ server {
     include fastcgi_params;
     fastcgi_intercept_errors on;
     fastcgi_pass php:9000;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
+    fastcgi_buffers 128 4096k;
+    fastcgi_buffer_size 4096k;
     fastcgi_connect_timeout 3000s;
     fastcgi_send_timeout 3000s;
     fastcgi_read_timeout 3000s;


### PR DESCRIPTION
Some local dev-env sites are 502ing whenever a POST request is sent from wp-admin. This is due to an error stating:
` 502 bad gateway
2022/01/20 02:47:05 [error] 102#102: *128 upstream sent too big header while reading response header from upstream, client: 172.20.0.2, server: localhost, request: “GET /wp-admin/edit.php?s=&post_status=all&post_type=post&_wpnonce=0bd12f11ce&_wp_http_referer=%2Fwp-admin%2Fedit.php&m=0&cat=0&capi_content_type=0&liveblog_state=&filter_action=Filter&paged=1 HTTP/1.1”, upstream: “fastcgi://172.21.0.8:9000”, host: “newsdna.vipdev.lndo.site”`

Have replicated locally and it seems their sites are sending a large header request. Updating these values within `etc/nginx/conf.d/default.conf` fixes this issue.