### PR TITLE
Bugfix - Missing WordPress Images post culling

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -47,5 +47,19 @@
     "cacheable": true,
     "locked": true,
     "prerelease": true
+  },
+  {
+    "ref": "5.8.1",
+    "tag": "5.8.1",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
+  },
+  {
+    "ref": "5.8.2",
+    "tag": "5.8.2",
+    "cacheable": true,
+    "locked": true,
+    "prerelease": false
   }
 ]


### PR DESCRIPTION
Added locked WordPress versions 5.8.1 and 5.8.2 to the WordPress manifest.
  * Retaining these should support users who have previously checked out these images into an environment.