### PR TITLE
CANTINA-844: synchronize PHP extensions with the production environment

### DIFF
--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v2
         with:
-          file: php-fpm/Dockerfile
+          context: php-fpm
           platforms: linux/amd64,linux/arm64
           # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
           push: ${{ github.base_ref == null }}

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,29 +1,64 @@
 FROM php:7.4-fpm-alpine3.14
 
-RUN apk update && \
-    apk add --no-cache less bash mariadb-client gd shadow && \
-    apk add --no-cache --virtual build-deps $PHPIZE_DEPS build-base zlib-dev libffi-dev openssl-dev libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev && \
+RUN apk add --no-cache less bash mariadb-client \
+    # memcache
+    zlib \ 
+    # ssh2
+    libssh2 \
+    # gmagick
+    ghostscript-fonts graphicsmagick libgomp \
+    # gd
+    freetype libjpeg-turbo libpng libwebp libxpm \
+    # gmp
+    gmp \
+    # intl
+    icu-libs \
+    # mcrypt
+    libmcrypt \
+    # soap
+    libxml2 \
+    # zip
+    libzip
+
+RUN \
+    apk add --no-cache --virtual build-deps $PHPIZE_DEPS build-base openssl-dev zlib-dev \
+        # mcrypt
+        libmcrypt-dev \
+        # ssh2
+        libssh2-dev \
+        # gmagick
+        graphicsmagick-dev libtool \
+        # gd
+        freetype-dev libjpeg-turbo-dev libpng-dev libwebp-dev libxpm-dev \
+        # gmp
+        gmp-dev \
+        # intl
+        icu-dev \
+        # soap
+        libxml2-dev \
+        # zip
+        libzip-dev && \
+    pecl channel-update pecl.php.net && \
     yes '' | pecl install -f memcache && \
-    docker-php-ext-install mysqli && \
-    docker-php-ext-enable memcache && \
-    docker-php-ext-install gd && \
-    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar && \
-    chmod a+x /usr/local/bin/phpunit && \
-    wget -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
-    chmod a+x /usr/local/bin/wp && \
-    pecl install xdebug && \
-    docker-php-ext-enable xdebug && \
+    pecl install apcu mcrypt timezonedb ssh2-1.3.1 gmagick-2.0.6RC1 xdebug && \
+    docker-php-ext-install -j$(nproc) bcmath calendar exif gd gmp intl mysqli pcntl shmop soap sockets sysvsem sysvshm zip && \
+    docker-php-ext-enable apcu gmagick mcrypt memcache ssh2 timezonedb xdebug opcache && \
+    docker-php-source delete && \
     apk del build-deps
+
+RUN \
+    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar && chmod a+x /usr/local/bin/phpunit && \
+    wget -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod a+x /usr/local/bin/wp
 
 ENV WP_CLI_CONFIG_PATH=/config/wp-cli.yaml
 
-COPY php-fpm/wp-cli.yaml /config/wp-cli.yaml
+COPY wp-cli.yaml /config/wp-cli.yaml
 
-COPY php-fpm/php.ini /usr/local/etc/php/php.ini
+COPY php.ini /usr/local/etc/php/php.ini
 
 # move it to backup location, run-php-fpm.sh will move it to conf.d if enabled
-COPY php-fpm/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
+COPY xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.template
 
-COPY php-fpm/run.sh /usr/local/bin/run.sh
+COPY run.sh /usr/local/bin/run.sh
 
 CMD ["run.sh"]


### PR DESCRIPTION
This PR adds the following extensions:
- apcu
- bcmath
- calendar
- exif
- gmagick
- gmp
- intl
- mcrypt
- pcntl
- shmop
- soap
- sockets
- ssh2
- sysvsem
- sysvshm
- timezonedb
- zip

Enables:
- Zend OPcache

What's missing:
- newrelic (it requires a license key)

