### PR TITLE
Pull base images and properly scope cache

### DIFF
--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -42,6 +42,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
           push: ${{ github.base_ref == null }}
+          pull: true
+          cache-from: type=gha,scope=php-fpm
+          cache-to: type=gha,mode=max,scope=php-fpm
           tags: |
             ghcr.io/automattic/vip-container-images/php-fpm:latest
             ghcr.io/automattic/vip-container-images/php-fpm:${{ steps.getversion.outputs.version }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -80,8 +80,8 @@ jobs:
           push: ${{ github.base_ref == null }}
           pull: true
           build-args: WP_GIT_REF=${{ matrix.wp.ref }}
-          cache-from: type=gha,scope=wordpress
-          cache-to: type=gha,mode=max,scope=wordpress
+          cache-from: type=gha,scope=wordpress-${{ matrix.wp.ref }}
+          cache-to: type=gha,mode=max,scope=wordpress-${{ matrix.wp.ref }}
           no-cache: ${{ matrix.wp.cacheable == false }}
           tags: |
             ghcr.io/automattic/vip-container-images/wordpress:${{ matrix.wp.tag }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -78,9 +78,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: wordpress
           push: ${{ github.base_ref == null }}
+          pull: true
           build-args: WP_GIT_REF=${{ matrix.wp.ref }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=wordpress
+          cache-to: type=gha,mode=max,scope=wordpress
           no-cache: ${{ matrix.wp.cacheable == false }}
           tags: |
             ghcr.io/automattic/vip-container-images/wordpress:${{ matrix.wp.tag }}


### PR DESCRIPTION
For builds where we use caching,
* pull base images before build: this is to ensure that we have the freshest of the base image (e.g., with the latest security patches applied);
* scope cache to "subproject": to ensure that cache for one build (e.g., wordpress) does not overwrite the cache for another build (say, php-fpm). Although nothing critical happens in case when one cache overwrites another, docker will be unable to use the cache which defeats the whole purpose of caching
