### PR TITLE
Separate 'pecl install' steps and clean up PEAR cache

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -40,11 +40,17 @@ RUN \
         libzip-dev && \
     pecl channel-update pecl.php.net && \
     yes '' | pecl install -f memcache && \
-    pecl install apcu mcrypt timezonedb ssh2-1.3.1 gmagick-2.0.6RC1 xdebug && \
+    pecl install apcu && \
+    pecl install mcrypt && \
+    pecl install timezonedb && \
+    pecl install ssh2-1.3.1 && \
+    pecl install gmagick-2.0.6RC1 && \
+    pecl install xdebug && \
     docker-php-ext-install -j$(nproc) bcmath calendar exif gd gmp intl mysqli pcntl shmop soap sockets sysvsem sysvshm zip && \
     docker-php-ext-enable apcu gmagick mcrypt memcache ssh2 timezonedb xdebug opcache && \
     docker-php-source delete && \
-    apk del build-deps
+    apk del build-deps && \
+    rm -rf /tmp/pear ~/.pearrc
 
 RUN \
     wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar && chmod a+x /usr/local/bin/phpunit && \


### PR DESCRIPTION
From the [documentation](https://hub.docker.com/_/php),

> Unlike PHP core extensions, PECL extensions should be installed in series to fail properly if something went wrong. Otherwise errors are just skipped by PECL. For example, pecl install memcached-3.1.4 && pecl install redis-5.1.1 instead of pecl install memcached-3.1.4 redis-5.1.1. However, docker-php-ext-enable memcached redis is fine to be all in one command.
