### PR TITLE
[nginx] Update rewrite rules

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -19,12 +19,11 @@ server {
 
   include /etc/nginx/conf.extra/*.conf;
 
-  # Support multisites in subdirectories mode. 
+  # Support multisites in subdirectories mode.
   # ie: local.vipdev.lndo.site/subsite1/wp-admin/ should be rewritten to /wp-admin/ folder.
-  if (!-e $request_filename) {
-    rewrite ^(/[^/]+)?(/wp-.*) $2 last;
-    rewrite ^(/[^/]+)?(/.*\.php) $2 last;
-  }
+  rewrite ^/([_0-9a-zA-Z-]+/|[_0-9a-zA-Z-]+/[_0-9a-zA-Z-]+/)?(wp-(content|admin|includes)/.*) /$2 last;
+  rewrite ^/([_0-9a-zA-Z-]+/[_0-9a-zA-Z-]+/|[_0-9a-zA-Z-]+/)?(.*.php)$ /$2 last;
+  rewrite ^/([_0-9a-zA-Z-]+/|[_0-9a-zA-Z-]+/[_0-9a-zA-Z-]+/)(_static/.*) /$2;
 
   location = /favicon.ico {
     log_not_found off;


### PR DESCRIPTION
When using WP for multisite in subdirectory mode, the urls would not be routed correctly.

For example. `http://multisite.vipdev.lndo.site/test/wp-admin` would end in an infinite redirect.

These rules that mimic closely our prod settings should suppress that. As they rewrite the file lookup on server from <subsite>/(wp-admin|wp-includes|wp-content|...) to exclude the subsite bit.