### PR TITLE
Explicitly chown /wp during dev-tools/setup.sh to avoid permission errors

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -11,6 +11,12 @@ wp_url=$3
 wp_title=$4
 multisite_domain=$5
 
+# Force-set owner to www-data otherwise we may run in to the permissions trouble during the initial start.
+# It manifests as 'Warning: require(/wp/wp-includes/pomo/mo.php): failed to open stream: No such file or directory'
+# Due to wp-includes being owned by root at the moment of script execution
+# It doesn't happen often and hard to reproduce
+chown www-data -R /wp
+
 if [ -r /wp/config/wp-config.php ]; then
   echo "Already existing wp-config.php file"
 else


### PR DESCRIPTION
There was a bug that manifested in the following error on the initial start/installation. Weirdly, it works on the restart, so I decided to `ls -al`  during the script and found out that some folders inside `/wp` have root as the owner. 

```
Warning: require(/wp/wp-includes/pomo/mo.php): failed to open stream: No such file or directory in /wp/wp-settings.php on line 116 [$ /usr/local/bin/wp option get siteurl] [wp-settings.php:116 require(''), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1317 require('wp-settings.php'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1235 WP_CLI\Runner-&gt;load_wordpress(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner-&gt;start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:78 WP_CLI\Bootstrap\LaunchRunner-&gt;process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```

It's as almost like something does `chown` but forgetting the `-R` flag on the first run, or some weird race condition.

I'm not positive this won't break something else 😬 But it does fix the bug!
