### PR TITLE
chown with "--silent" in setup.sh

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -15,7 +15,7 @@ multisite_domain=$5
 # It manifests as 'Warning: require(/wp/wp-includes/pomo/mo.php): failed to open stream: No such file or directory'
 # Due to wp-includes being owned by root at the moment of script execution
 # It doesn't happen often and hard to reproduce
-chown www-data -R /wp
+chown --silent www-data -R /wp
 
 if [ -r /wp/config/wp-config.php ]; then
   echo "Already existing wp-config.php file"


### PR DESCRIPTION
add --silent tag to chown operation so as to not cause panic if the chown cannot be performed

prevents someone from seeing the unsightly eyesore in this image:
![Screen Shot 2022-02-28 at 8 04 22 AM](https://user-images.githubusercontent.com/46167019/156006636-2900c72a-d1c4-440f-8ea6-f09ef410bc27.png)

