### PR TITLE
Supress https redirects

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -1,22 +1,49 @@
 <?php
 
-add_filter( 'set_url_scheme', function( $url ) {
-    $proto = $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ?? '';
 
-    if ( 'https' == $proto ) {
-        return str_replace( 'http://', 'https://', $url );
-    }
-    return $url;
+/******************
+ * Handle HTTPS
+ ******************/
+
+add_filter( 'set_url_scheme', function( $url ) {
+	$proto = $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ?? '';
+
+	if ( 'https' == $proto ) {
+		return str_replace( 'http://', 'https://', $url );
+	}
+	return $url;
 });
+
+/**
+ * In some scenarios https is not correctly detected. That leads to infinite redirect to https.
+ * Infinite because you already are on https
+ */
+add_filter( 'redirect_canonical', function( $redirect_url, $requested_url ) {
+	$https_request_version    = str_replace( 'http://', 'https://', $requested_url );
+	$is_redirecting_for_https = $https_request_version === $redirect_url;
+	if ( $is_redirecting_for_https ) {
+		return;
+	}
+
+	return $redirect_url;
+}, 10, 2);
+
+/******************
+ * 2FA
+ ******************/
 
 // Disable Two_Factor_FIDO_U2F Profider for the dev-env
 add_filter('two_factor_providers', function( $providers ) {
-    unset( $providers['Two_Factor_FIDO_U2F'] );
-    return $providers;
+	unset( $providers['Two_Factor_FIDO_U2F'] );
+	return $providers;
 });
 
+/******************
+ * ADMIN USER CREATION
+ ******************/
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-    WP_CLI::add_command( 'dev-env-add-admin', 'dev_env_add_admin' );
+	WP_CLI::add_command( 'dev-env-add-admin', 'dev_env_add_admin' );
 }
 
 /**
@@ -37,35 +64,35 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  * wp dev-env-add-admin --username=vipgo --password=test
  */
 function dev_env_add_admin( $args, $assoc_args ) {
-    $username = $assoc_args['username'] ?? '';
-    $password = $assoc_args['password'] ?? '';
-    $email = $assoc_args['email'] ?? $username . '@go-vip.net';
+	$username = $assoc_args['username'] ?? '';
+	$password = $assoc_args['password'] ?? '';
+	$email = $assoc_args['email'] ?? $username . '@go-vip.net';
 
-    if ( ! $username || ! $password ) {
-        WP_CLI::error( 'Both username and password need to be provided!' );
-    }
+	if ( ! $username || ! $password ) {
+		WP_CLI::error( 'Both username and password need to be provided!' );
+	}
 
-    if ( username_exists( $username ) ) {
-        WP_CLI::line( 'User "' . $username . '" already exits. Skipping creating it.' );
-        return;
-    }
+	if ( username_exists( $username ) ) {
+		WP_CLI::line( 'User "' . $username . '" already exits. Skipping creating it.' );
+		return;
+	}
 
-    WP_CLI::runcommand( 'user create ' . $username . ' ' . $email . ' --user_pass=' . $password . ' --role=administrator' );
-    WP_CLI::success( 'User "' . $username . '" created.' );
+	WP_CLI::runcommand( 'user create ' . $username . ' ' . $email . ' --user_pass=' . $password . ' --role=administrator' );
+	WP_CLI::success( 'User "' . $username . '" created.' );
 
-    if ( is_multisite() ) {
-        // on multisite we do more setup
-        WP_CLI::runcommand( 'super-admin add ' . $username );
-        WP_CLI::success( 'User "' . $username . '" added to super-admin list.' );
+	if ( is_multisite() ) {
+		// on multisite we do more setup
+		WP_CLI::runcommand( 'super-admin add ' . $username );
+		WP_CLI::success( 'User "' . $username . '" added to super-admin list.' );
 
-        $sites = get_sites();
-        foreach ( $sites as $site ) {
-            switch_to_blog( $site->blog_id );
-            $subsite_url = home_url();
+		$sites = get_sites();
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site->blog_id );
+			$subsite_url = home_url();
 
-            WP_CLI::runcommand( 'user set-role ' . $username . ' administrator --url=' . $subsite_url );
+			WP_CLI::runcommand( 'user set-role ' . $username . ' administrator --url=' . $subsite_url );
 
-            restore_current_blog();
-        }
-    }
+			restore_current_blog();
+		}
+	}
 }


### PR DESCRIPTION
In specific cases we get an infinite https -> https redirect. Here is one scenario to reproduce:

* dev-env create --slug test
* go to wp-admin
* Settings -> Readign
* Go to https version of homepage - https://test.vipdev.lndo.site/ -> infinite redirect

* vim /home/pavel/.local/share/vip/dev-environment/test/.lando.yml
* Change devtools from image to local build:
```
      build:
        context: /home/pavel/git/automattic/vip-container-images
        dockerfile: /home/pavel/git/automattic/vip-container-images/dev-tools/Dockerfile
```
*  dev-env destroy --soft --slug test (because docker volumes are fun!)
* repeat the first steps again
* Should work fine now.

The fix here suppresses redirects that are only due to http -> https which makes life easier on local dev-env.