### PR TITLE
dev-env update WordPress image selection

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -7,7 +7,7 @@
     "prerelease": false
   },
   {
-    "ref": "5.9.2",
+    "ref": "5.9.3",
     "tag": "5.9",
     "cacheable": true,
     "locked": true,
@@ -30,27 +30,6 @@
   {
     "ref": "5.7.5",
     "tag": "5.7",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
-    "ref": "5.8.3",
-    "tag": "5.8.3",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
-    "ref": "5.8.1",
-    "tag": "5.8.1",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
-    "ref": "5.8.2",
-    "tag": "5.8.2",
     "cacheable": true,
     "locked": true,
     "prerelease": false


### PR DESCRIPTION
  * Removed images for 5.8.3, 5.8.2, 5.8.1 (They were there for legacy reasons but they need to be moved beyond at this point)
  * Changed the 5.9 ref to 5.9.3 as is the new release as of yesterday.