### PR TITLE
Rename the tag to 6.0

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "2be90dc589a1c2e2bde5efa691eafe5407d0f753",
-    "tag": "6.0-beta1",
+    "tag": "6.0",
     "cacheable": true,
     "locked": true,
     "prerelease": true


### PR DESCRIPTION
Follow up to #186, it seems `6.0-beta1` doesn't work as a tag.