### PR TITLE
Remove 6.0 as there's a bug in VIP-CLI preventing the user from actually using it

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,12 +1,5 @@
 [
   {
-    "ref": "2be90dc589a1c2e2bde5efa691eafe5407d0f753",
-    "tag": "6.0",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": true
-  },
-  {
     "ref": "5.9.3",
     "tag": "5.9",
     "cacheable": true,


### PR DESCRIPTION
There's going to be a follow-up PR with the fix for VIP-CLI