### PR TITLE
Update WordPress add-version.sh script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,23 @@ The image publishing process is performed by [a GitHub action](.github/workflows
 
 This repository has Dependabot [set up](.github/dependabot.yml). Whenever a Docker base image has a new available version, the bot will open a Pull Request with the change.
 
-## Adding, Updating, and Removing Subtrees
-There are scripts that can be used to add, update and remove WordPress version subtrees. Interface with these scripts in the following ways:
+## Adding, Updating and Deleting versions of WordPress
 
-`$> wordpress/add-version.sh 5.9.1 5.9.1`
-  This can be used to add a new WordPress version. The second parameter is a tag for the github repository. Alternatively you can use a commit hash.
+We have utility scripts to add and remove the versions of WordPress, based on the versions.json we kick off the image builds for every specified version. We use [official GitHub repo for WordPress](https://github.com/WordPress/WordPress). 
 
-`$> wordpress/update-version.sh 5.9.1`
-  This can be used to update a version to its most recent tag/commit.
+Basic syntax is as follows
 
-`$> wordpress/delete-version.sh 5.9.1`
-  This can be used to delete a subtree.
+`$> wordpress/add-version.sh <TAG> <REF> [cacheable=true] [locked=false] [prerelease=false]`
+
+- `<TAG>` is Docker image tag, should be pointing to the major version, E.g. `5.8`
+- `<REF>` is either git tag, e.g. `5.8.3` or git SHA, e.g. `e86b90cad6330eea636496f7317fac4c1a73e42b`
+
+`$> wordpress/add-version.sh 6.0 2be90dc589a1c2e2bde5efa691eafe5407d0f753 true true true`
+This will add a 6.0 (pre-release) and point to a specific commit
+
+`$> wordpress/add-version.sh 5.9 5.9.3`
+This will add a 5.9 and point to 5.9.3 tag.
+
+`$> wordpress/delete-version.sh 5.9`
+This can be used to delete tag.
+Alternatively, this also can be done by removing the related entry from `wordpress/versions.json`

--- a/wordpress/add-version.sh
+++ b/wordpress/add-version.sh
@@ -15,30 +15,35 @@ REF="$2"
 
 CACHEABLE=true
 if [ -n "$3" ]; then
-    if [ "$3" eq "false" ]; then
+    if [ "$3" == "false" ]; then
         CACHEABLE=false
     fi
 fi
 
 LOCKED=false
 if [ -n "$4" ]; then
-    if [ "$4" eq "true" ]; then
+    if [ "$4" == "true" ]; then
         LOCKED=true
     fi
 fi
 
 PRERELEASE=false
 if [ -n "$5" ]; then
-    if [ "$5" eq "true" ]; then
+    if [ "$5" == "true" ]; then
         PRERELEASE=true
     fi
 fi
+echo ""
+echo "Adding version: $TAG at ref: $REF"
+echo "Cacheable: $CACHEABLE"
+echo "Locked: $LOCKED"
+echo "Prerelease: $PRERELEASE"
 
 VERSIONS="$(dirname "$0")/versions.json"
 
 exists=$(jq -r ".[] | select(.tag == \"${TAG}\") | .ref" "${VERSIONS}")
 if [ -z "${exists}" ]; then
-    jq ". += [{ref: \"${REF}\", tag: \"${TAG}\", cacheable: ${CACHEABLE}, locked: ${LOCKED}, prerelease: ${PRERELEASE} }] | sort" "${VERSIONS}" | sponge "${VERSIONS}"
+    jq ". += [{ref: \"${REF}\", tag: \"${TAG}\", cacheable: ${CACHEABLE}, locked: ${LOCKED}, prerelease: ${PRERELEASE} }] | sort_by(.tag) | reverse" "${VERSIONS}" | sponge "${VERSIONS}"
 else
     echo "${TAG} already exists in versions.json"
 fi


### PR DESCRIPTION
Update wordpress/add-version.sh to be more explicit about the parameters, fix eq comparisons resulting in the incorrect values for cacheable, locked and prerelease, sort the list of versions in reverse chronological order (newest first)