### PR TITLE
Add debug mode to debug failed tests

### DIFF
--- a/wp-core-test-runner/runner.sh
+++ b/wp-core-test-runner/runner.sh
@@ -25,5 +25,13 @@ if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
 	"${PRETEST_SCRIPT}"
 fi
 
-# shellcheck disable=SC2086
-cd "${HOME}/wordpress-core/" && ${PHP} "${HOME}/wordpress-core/vendor/bin/phpunit" ${PHPUNIT_ARGS}
+if [ -z "${RUN_TESTS}" ]; then
+	# shellcheck disable=SC2086
+	cd "${HOME}/wordpress-core/" && ${PHP} "${HOME}/wordpress-core/vendor/bin/phpunit" ${PHPUNIT_ARGS}
+	retval=$?
+	if [ $retval -ne 0 ] && [ -n "${DEBUG_TESTS}" ]; then
+		/bin/bash -i
+	fi
+else
+	/bin/bash -i
+fi

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -19,6 +19,14 @@ if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
 	"${PRETEST_SCRIPT}"
 fi
 
-echo "Running tests..."
-# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
-${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
+if [ -z "${RUN_TESTS}" ]; then
+	echo "Running tests..."
+	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
+	${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"
+	retval=$?
+	if [ $retval -ne 0 ] && [ -n "${DEBUG_TESTS}" ]; then
+		/bin/bash -i
+	fi
+else
+	/bin/bash -i
+fi


### PR DESCRIPTION
This PR adds to variables to test runners:
  * `RUN_TESTS`: when not empty, run an interactive shell instead of running tests. This allows for running tests with custom parameters or modifying scripts locally;
  * `DEBUG_TESTS`: when not empty and the test script exited with a non-zero code, run an interactive shell for debugging.
