### PR TITLE
Rename RUN_TESTS to SKIP_TESTS to match what it actually does

### DIFF
--- a/wp-core-test-runner/runner.sh
+++ b/wp-core-test-runner/runner.sh
@@ -25,7 +25,7 @@ if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
 	"${PRETEST_SCRIPT}"
 fi
 
-if [ -z "${RUN_TESTS}" ]; then
+if [ -z "${SKIP_TESTS}" ]; then
 	# shellcheck disable=SC2086
 	cd "${HOME}/wordpress-core/" && ${PHP} "${HOME}/wordpress-core/vendor/bin/phpunit" ${PHPUNIT_ARGS}
 	retval=$?

--- a/wp-test-runner/runner.sh
+++ b/wp-test-runner/runner.sh
@@ -19,7 +19,7 @@ if [ -n "${PRETEST_SCRIPT}" ] && [ -x "${PRETEST_SCRIPT}" ]; then
 	"${PRETEST_SCRIPT}"
 fi
 
-if [ -z "${RUN_TESTS}" ]; then
+if [ -z "${SKIP_TESTS}" ]; then
 	echo "Running tests..."
 	# shellcheck disable=SC2086 # PHPUNIT_ARGS should not be quoted
 	${PHP} "${PHPUNIT}" ${PHPUNIT_ARGS} "$@"


### PR DESCRIPTION
Fix a bug introduced in #190.

An empty value for `RUN_TESTS` caused the runner to run tests, not skip them. This made `RUN_TESTS=1` counterintuitive, as this would cause the runner not to run the tests.

This PR renames `RUN_TESTS` to `SKIP_TESTS` to match what the variable actually controls.
