### PR TITLE
Create a symlink to /usr/bin/php

### DIFF
--- a/php-fpm-alt/Dockerfile.80
+++ b/php-fpm-alt/Dockerfile.80
@@ -49,6 +49,7 @@ RUN \
 
 RUN ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm
 RUN ln -s /usr/bin/pecl8 /usr/bin/pecl
+RUN ln -s /usr/bin/php8 /usr/bin/php
 
 RUN \
     pecl update-channels && \

--- a/php-fpm-alt/Dockerfile.81
+++ b/php-fpm-alt/Dockerfile.81
@@ -50,6 +50,7 @@ RUN \
 
 RUN ln -s /usr/sbin/php-fpm81 /usr/sbin/php-fpm
 RUN ln -s /usr/bin/pecl81 /usr/bin/pecl
+RUN ln -s /usr/bin/php81 /usr/bin/php
 
 RUN \
     pecl update-channels && \


### PR DESCRIPTION
8.0 and 8.1 images miss /usr/bin/php; this prevents WP CLI form running. As a result, `vip dev-env start` is unable to install WordPress automatically.
