### PR TITLE
Implement a simple check that runs until the files are copied to make sure setup only proceeds after, otherwise we're risking race conditions

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -13,9 +13,16 @@ multisite_domain=$5
 
 # Make sure to check the core files are there before trying to install WordPress.
 echo "Waiting for core files to be copied"
+i=0;
 while [ ! -f /wp/wp-includes/pomo/mo.php ]
 do
   sleep 0.5
+  i=$((i+1))
+  # Roughly 30 seconds
+  if [ $i -eq 60 ]; then
+    echo "Timeout exceeded"
+    break
+  fi
 done
 
 

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -18,8 +18,8 @@ while [ ! -f /wp/wp-includes/pomo/mo.php ]
 do
   sleep 0.5
   i=$((i+1))
-  # Roughly 30 seconds
-  if [ $i -eq 60 ]; then
+  # Roughly 1 minute
+  if [ $i -eq 120 ]; then
     echo "Timeout exceeded"
     break
   fi

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -11,11 +11,13 @@ wp_url=$3
 wp_title=$4
 multisite_domain=$5
 
-# Force-set owner to www-data otherwise we may run in to the permissions trouble during the initial start.
-# It manifests as 'Warning: require(/wp/wp-includes/pomo/mo.php): failed to open stream: No such file or directory'
-# Due to wp-includes being owned by root at the moment of script execution
-# It doesn't happen often and hard to reproduce
-chown --silent www-data -R /wp
+# Make sure to check the core files are there before trying to install WordPress.
+echo "Waiting for core files to be copied"
+while [ ! -f /wp/wp-includes/pomo/mo.php ]
+do
+  sleep 0.5
+done
+
 
 if [ -r /wp/config/wp-config.php ]; then
   echo "Already existing wp-config.php file"


### PR DESCRIPTION
It remains to be seen whether `/wp/wp-includes/pomo/mo.php` is a good thing to check or if there's something else we should check.

This also removed the `chown` as it doesn't seem to be helpful in the situation.

There's going to be a counter-part on the CLI side to get rid of the PHP healthcheck as it's also not helpful

