### PR TITLE
Update and pin GitHub actions for php-fpm-alt workflow

### DIFF
--- a/.github/workflows/php-fpm-alt.yml
+++ b/.github/workflows/php-fpm-alt.yml
@@ -31,19 +31,19 @@ jobs:
             suffix: "81"
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16 # tag=v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # tag=v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # tag=v1.7.0
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # tag=v1
         with:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # tag=v2.7.0
         with:
           context: php-fpm-alt
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Dependabot is too tired to do that, have to update GHA manually.