### PR TITLE
WordPress: add 6.0-RC1 and trunk.

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -41,11 +41,11 @@
     "locked": true,
     "prerelease": false
   },
-	{
-		"ref": "HEAD",
-		"tag": "trunk",
-		"cacheable": false,
-		"locked": false,
-		"prerelease": true
-	}
+  {
+    "ref": "HEAD",
+    "tag": "trunk",
+    "cacheable": false,
+    "locked": false,
+    "prerelease": true
+  }
 ]

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -7,6 +7,13 @@
     "prerelease": true
   },
   {
+    "ref": "638a31b8d3000eb7d0c13b84ec6c7f5740cffe4f",
+    "tag": "6.0-RC1",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": true
+  },
+  {
     "ref": "5.9.3",
     "tag": "5.9",
     "cacheable": true,

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,5 +1,12 @@
 [
   {
+    "ref": "HEAD",
+    "tag": "trunk",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": true
+  },
+  {
     "ref": "5.9.3",
     "tag": "5.9",
     "cacheable": true,

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,12 +1,5 @@
 [
   {
-    "ref": "HEAD",
-    "tag": "trunk",
-    "cacheable": false,
-    "locked": false,
-    "prerelease": true
-  },
-  {
     "ref": "638a31b8d3000eb7d0c13b84ec6c7f5740cffe4f",
     "tag": "6.0-RC1",
     "cacheable": true,
@@ -47,5 +40,12 @@
     "cacheable": true,
     "locked": true,
     "prerelease": false
-  }
+  },
+	{
+		"ref": "HEAD",
+		"tag": "trunk",
+		"cacheable": false,
+		"locked": false,
+		"prerelease": true
+	}
 ]

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -2,7 +2,7 @@
   {
     "ref": "HEAD",
     "tag": "trunk",
-    "cacheable": true,
+    "cacheable": false,
     "locked": false,
     "prerelease": true
   },


### PR DESCRIPTION
This PR adds `trunk` which just points to HEAD of the GitHub repo, and 6.0-RC1 which points to https://github.com/WordPress/WordPress/commit/638a31b8d3000eb7d0c13b84ec6c7f5740cffe4f