### PR TITLE
Add JPEG support to GD

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -46,6 +46,7 @@ RUN \
     pecl install ssh2-1.3.1 && \
     pecl install gmagick-2.0.6RC1 && \
     pecl install xdebug && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-xpm && \
     docker-php-ext-install -j$(nproc) bcmath calendar exif gd gmp intl mysqli pcntl shmop soap sockets sysvsem sysvshm zip && \
     docker-php-ext-enable apcu gmagick mcrypt memcache ssh2 timezonedb xdebug opcache && \
     docker-php-source delete && \


### PR DESCRIPTION
See z-148012

Steps to test:
1. Build the image
2. Run the newly built image:
```sh
docker run -it --rm ghcr.io/automattic/vip-container-images/php-fpm:7.4 php -i | grep -F 'JPEG Support'
```
3. `JPEG Support => enabled` should appear

The expected `libgd`-related output from `php -i`:
```
gd

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.10.4
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 8
PNG Support => enabled
libPNG Version => 1.6.37
WBMP Support => enabled
XPM Support => enabled
libXpm Version => 30411
XBM Support => enabled
WebP Support => enabled
BMP Support => enabled
TGA Read Support => enabled
```
