### PR TITLE
Make chowning folder optional

### DIFF
--- a/dev-tools/scripts/user-container-setup.sh
+++ b/dev-tools/scripts/user-container-setup.sh
@@ -55,5 +55,8 @@ if [ "$LANDO_WEBROOT_UID" != "$LANDO_HOST_UID" ]; then
         exit 1;
     fi
 
-    chown -R "$LANDO_WEBROOT_USER" "/home/$LANDO_WEBROOT_USER"
+    if [[ -d "/home/$LANDO_WEBROOT_USER" ]]; then
+        lando_info "Making $LANDO_WEBROOT_USER owner of /home/$LANDO_WEBROOT_USER"
+        chown -R "$LANDO_WEBROOT_USER" "/home/$LANDO_WEBROOT_USER"
+    fi
 fi


### PR DESCRIPTION
On some images like `wordpress` or `dev-tools` there is no `/www/data` folder resulting in failure in backup user permissions script.

Testing this is a bit difficult as it is hard to trigger the scenario where the base lando user logic fails (your user id needs to be quite high is one way of doing it).

What I have done is changed the script condition to something like `[ 1 == 1 ] `, following the README configure one of my dev-envs to use local build for devtools instead of image and dropped volumes before every test using `destroy`.