### PR TITLE
patch multisite not installed check

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -54,7 +54,7 @@ site_exist_check_output=$(wp option get siteurl 2>&1);
 
 site_exist_return_value=$?;
 site_installed=1;
-if [[ "$site_exist_check_output" == *"The site you have requested is not installed"* ]]; then
+if [[ "$site_exist_check_output" == *"The site you have requested is not installed"* ]] || echo "$site_exist_check_output" | grep -q "Site .* not found"; then
   site_installed=0;
 fi
 


### PR DESCRIPTION
The error for `wp option get siteurl` is different between a single and multisite.

Single: Error: The site you have requested is not installed.
https://github.com/wp-cli/wp-cli/blob/0b22dee2eabcfc9f9f84671003900155b0722543/php/utils-wp.php#L35

Multisite: Error: Site ‘969.vipdev.lndo.site/’ not found. Verify DOMAIN_CURRENT_SITE matches an existing site or use `--url=<url>` to override.

This change handles both variants.