### PR TITLE
Add support for .x WP versions

### DIFF
--- a/wp-test-runner/install-wp.sh
+++ b/wp-test-runner/install-wp.sh
@@ -18,6 +18,13 @@ download_wp() {
 		ln -sf "/wordpress/wordpress-${LATEST}" /wordpress/wordpress-latest
 		ln -sf "/wordpress/wordpress-tests-lib-${LATEST}" /wordpress/wordpress-tests-lib-latest
 		return
+	elif [ "${VERSION%.x}" != "${VERSION}" ]; then
+		VER="${VERSION}"
+		LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq --arg version "${VERSION%.x}" -r '.offers | map(select(.version | startswith($version))) | sort_by(.version) | reverse | .[0].version')
+		download_wp "${LATEST}"
+		ln -sf "/wordpress/wordpress-${LATEST}" "/wordpress/wordpress-${VER}"
+		ln -sf "/wordpress/wordpress-tests-lib-${LATEST}" "/wordpress/wordpress-tests-lib-${VER}"
+		return
 	else
 		TESTS_TAG="tags/${VERSION}"
 	fi


### PR DESCRIPTION
This PR adds support for `.x` WordPress versions.

Thus,

```sh
install-wp 5.9.x
```

will install the latest available WordPress in the 5.9 release.

Our CI jobs will benefit from this: we can do something like

```yaml
  php74-build-singlesite-59:
    <<: *php_job
    environment:
      WP_MULTISITE: "0"
      WP_VERSION: "5.9.x"
      PHPUNIT_VERSION: "7"
    docker:
      - image: ghcr.io/automattic/vip-container-images/wp-test-runner:latest
      - image: *db_image
```

without having to update the job definition every time a new WordPress update is released.

Steps to test:
```sh
docker build -t xxx .
docker run -it --rm --entrypoint /bin/bash xxx
```

In the container:
```sh
install-wp 5.9.x
ls -lha /wordpress
```

Observe that the script has created two symlinks:
```
...
lrwxrwxrwx 1 circleci circleci   26 May 28 21:54 wordpress-5.9.x -> /wordpress/wordpress-5.9.3
...
lrwxrwxrwx 1 circleci circleci   36 May 28 21:54 wordpress-tests-lib-5.9.x -> /wordpress/wordpress-tests-lib-5.9.3
```
