### PR TITLE
Add wp-test-base image

### DIFF
--- a/.github/workflows/wp-test-base.yml
+++ b/.github/workflows/wp-test-base.yml
@@ -1,0 +1,52 @@
+name: Build WP Test Base image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "wp-test-base/**"
+      - ".github/workflows/wp-test-base.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "wp-test-base/**"
+      - ".github/workflows/wp-test-base.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # tag=v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # tag=v2.0.0
+
+      - name: Build and push
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # tag=v3.0.0
+        with:
+          context: wp-test-base
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/automattic/vip-container-images/wp-test-base:latest

--- a/wp-test-base/Dockerfile
+++ b/wp-test-base/Dockerfile
@@ -1,0 +1,40 @@
+FROM cimg/base:stable-20.04@sha256:087e0c2f4f3702c9080b726e240ec4e649eb3242cc2b453c8a49476a40bc50d1
+
+USER root
+RUN \
+	export DEBIAN_FRONTEND=noninteractive; \
+	echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+	apt-get -qq update && apt-get -qq install eatmydata && \
+	add-apt-repository -y ppa:ondrej/php && \
+	eatmydata apt-get -qq upgrade && \
+	eatmydata apt-get -qq install php7.4 php7.4-apcu php7.4-curl php7.4-gd php7.4-gmp php7.4-igbinary php7.4-imagick php7.4-imap php7.4-intl php7.4-mbstring php7.4-mysql php7.4-sqlite3 php7.4-xdebug php7.4-xml php7.4-xsl php7.4-zip && \
+	eatmydata apt-get -qq install php8.0 php8.0-apcu php8.0-curl php8.0-gd php8.0-gmp php8.0-igbinary php8.0-imagick php8.0-imap php8.0-intl php8.0-mbstring php8.0-mysql php8.0-sqlite3 php8.0-xdebug php8.0-xml php8.0-xsl php8.0-zip && \
+	eatmydata apt-get -qq install php8.1 php8.1-apcu php8.1-curl php8.1-gd php8.1-gmp php8.1-igbinary php8.1-imagick php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xdebug php8.1-xml php8.1-zip && \
+	eatmydata apt-get -qq install subversion unzip default-mysql-client && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
+	echo "xdebug.mode=coverage" | tee /etc/php/*/mods-available/xdebug.ini && \
+	update-alternatives --set php /usr/bin/php7.4
+
+RUN install -d -o circleci -g circleci -m 0777 /wordpress
+RUN wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/bin/ --filename=composer
+
+RUN \
+	wget -q -O /usr/local/bin/phpunit7 https://phar.phpunit.de/phpunit-7.phar & \
+	wget -q -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar & \
+	wget -q -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar & \
+    wget -q -O /usr/local/bin/phpcov   https://phar.phpunit.de/phpcov.phar & \
+	wait; \
+	chmod +x /usr/local/bin/phpunit7 /usr/local/bin/phpunit8 /usr/local/bin/phpunit9 /usr/local/bin/phpcov
+
+USER circleci
+
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
+RUN composer global require phpunit/phpunit:^7 yoast/phpunit-polyfills:^1
+
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+ENV NVM_DIR /home/circleci/.nvm
+
+RUN \
+    . "${NVM_DIR}/nvm.sh" && \
+    nvm install --lts && \
+    nvm use --lts


### PR DESCRIPTION
This PR adds a `wp-test-base` image. The image contains things common to our test runner images.

Its main advantage is the reduced build time. Because our runner images ship `nightly` releases of WordPress, they have to be rebuilt at least daily. However, PHP, Node.js, PHPUnit, etc do not have to be updated that often. By extracting the common dependencies into a separate image, we will reduce the time needed to build our test runners.
