### PR TITLE
Update base image for php-fpm-alt:8.0

### DIFF
--- a/php-fpm-alt/Dockerfile.80
+++ b/php-fpm-alt/Dockerfile.80
@@ -1,4 +1,4 @@
-FROM alpine:3.15@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454
+FROM alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 
 RUN \
     apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client php8 php8-fpm php8-pear \
@@ -48,8 +48,6 @@ RUN \
         php8-zip
 
 RUN ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm
-RUN ln -s /usr/bin/pecl8 /usr/bin/pecl
-RUN ln -s /usr/bin/php8 /usr/bin/php
 
 RUN \
     pecl update-channels && \


### PR DESCRIPTION
* Bump alpine from 3.15.4 to 3.16.0;
* Do not create symlinks for `php` and `pecl`.
