### PR TITLE
Update mariadb-lite image

### DIFF
--- a/mariadb-lite/Dockerfile
+++ b/mariadb-lite/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/mariadb:10.3@sha256:6d3dea5cadaa21fdfd74cc0c0e6360a467090bae312c369c68c72c94704e54f4
+FROM mariadb:10.3@sha256:4fcbee53b67ef199eb379580382924aa7258d91147ac778f3489d004674f936e
 
 RUN \
     apt-get -qq update && \
@@ -6,4 +6,14 @@ RUN \
     eatmydata apt-get -qq upgrade && \
     rm -rf /var/lib/apt/lists/*
 
-ENV LD_PRELOAD libeatmydata.so
+ENV \
+    LD_PRELOAD=libeatmydata.so \
+    MYSQL_ALLOW_EMPTY_PASSWORD=true \
+    MYSQL_DATABASE=circle_test \
+    MYSQL_HOST=127.0.0.1 \
+    MYSQL_ROOT_HOST=% \
+    MYSQL_USER=root
+
+RUN \
+    echo '\n[mysqld]\ncollation-server = utf8_unicode_ci\ninit-connect="SET NAMES utf8"\ncharacter-set-server = utf8\ninnodb_flush_log_at_trx_commit=2\nsync_binlog=0\ninnodb_use_native_aio=0\n' >> /etc/mysql/my.cnf && \
+    echo '\n[mysqld]\ndatadir = /dev/shm/mysql\n' >> /etc/mysql/my.cnf


### PR DESCRIPTION
This PR switches the base image from `circleci/mariadb:10.3` to `mariadb:10.3` and applies CircleCI-specific changes because:
* CircleCI images are only built for the `amd64` architecture;
* the 10.3 branch does not seem to receive security updates.

As a bonus, this PR fixes 18 low and 72 medium security vulnerabilities.

We still have several unpatched vulnerabilities in MariaDB (no fix exists):
  * [mariadb: Improper Control of Generation of Code](https://avd.aquasec.com/nvd/cve-2021-27928);
  * [mariadb: Crash in set_var.cc via certain UPDATE queries with nested subqueries](https://avd.aquasec.com/nvd/cve-2021-46662);
  * [mariadb: Crash caused by mishandling of a pushdown from a HAVING clause](https://avd.aquasec.com/nvd/cve-2021-46666);
  * [mariadb: Integer overflow in sql_lex.cc integer leading to crash](https://avd.aquasec.com/nvd/cve-2021-46667);
  * [mariadb: MariaDB through 10.5.9 allows attackers to trigger a convert_const_to_int use-after-free when the BIGINT data type is used](https://avd.aquasec.com/nvd/2021/cve-2021-46669/);
  * [Duktape v2.99.99 was discovered to contain a SEGV vulnerability](https://avd.aquasec.com/nvd/cve-2021-46322)
