### PR TITLE
Bump ghcr.io/automattic/vip-container-images/alpine to 3.16.0

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -74,11 +74,9 @@ jobs:
       - name: Build WordPress image
         uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # tag=v3
         with:
-          file: wordpress/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: wordpress
           push: ${{ github.base_ref == null }}
-          pull: true
           build-args: WP_GIT_REF=${{ matrix.wp.ref }}
           cache-from: type=gha,scope=wordpress-${{ matrix.wp.ref }}
           cache-to: type=gha,mode=max,scope=wordpress-${{ matrix.wp.ref }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Images are built and published using GitHub Actions and GitHub Packages. All ima
 You can find the most up to date versions of the images and the command to pull them in the sidebar, under the _Packages_ section. TL;DR the pulling has to be prefixed with `ghcr.io/automattic/vip-container-images`. For instance:
 
 ```bash
-docker pull ghcr.io/automattic/vip-container-images/alpine:3.14.1
+docker pull ghcr.io/automattic/vip-container-images/alpine:3.16.0
 ```
 
 ### Using image locally in dev-env

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.15.4@sha256:81651cfe524426b5066c9670d8b816a505a605df9e1d8c3d16097026388ee402
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c978bcc1225803bb3c3e94922165c17814d599d8ac6dc11f32746
 
 COPY dev-tools/setup.sh dev-tools/add-site.sh dev-tools/dev-env-plugin.php dev-tools/wp-config* /dev-tools/
 COPY dev-tools/scripts /scripts

--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.15.4@sha256:81651cfe524426b5066c9670d8b816a505a605df9e1d8c3d16097026388ee402
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c978bcc1225803bb3c3e94922165c17814d599d8ac6dc11f32746
 
 RUN apk add --no-cache git && \
     git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins /mu-plugins && \

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.15.4@sha256:81651cfe524426b5066c9670d8b816a505a605df9e1d8c3d16097026388ee402
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c978bcc1225803bb3c3e94922165c17814d599d8ac6dc11f32746
 
 RUN apk add --no-cache --virtual build-deps git && \
     git clone https://github.com/Automattic/vip-go-skeleton/ /clientcode && \

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.15.4@sha256:81651cfe524426b5066c9670d8b816a505a605df9e1d8c3d16097026388ee402 AS build
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c978bcc1225803bb3c3e94922165c17814d599d8ac6dc11f32746 AS build
 ARG WP_GIT_REF
 RUN apk add --no-cache git git-subtree patch
 RUN mkdir /wordpress
@@ -17,5 +17,5 @@ RUN \
 
 COPY extra/ /wordpress/wordpress/
 
-FROM ghcr.io/automattic/vip-container-images/alpine:3.15.4@sha256:81651cfe524426b5066c9670d8b816a505a605df9e1d8c3d16097026388ee402
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c978bcc1225803bb3c3e94922165c17814d599d8ac6dc11f32746
 COPY --from=build /wordpress/wordpress/ /wp/


### PR DESCRIPTION
Update `ghcr.io/automattic/vip-container-images/alpine` from 3.15.4 to 3.16.0