### PR TITLE
Fix multiple security issues in statsd image

### DIFF
--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # tag=v3
         with:
-          file: statsd/Dockerfile
+          context: statsd
           platforms: linux/amd64,linux/arm64
           # base_ref is only defined in PRs, hence we're only pushing when we're not in a PR
           push: ${{ github.base_ref == null }}

--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,5 +1,12 @@
-FROM statsd/statsd:v0.9.0@sha256:d7e6f2261ffeb96eff30f04c77e46959a6ddb23c492675196ceaeac5947e898c
+FROM statsd/statsd:v0.9.0@sha256:d7e6f2261ffeb96eff30f04c77e46959a6ddb23c492675196ceaeac5947e898c AS build
 
-COPY statsd/statsd-config.js /config/statsd-config.js
+FROM node:gallium-bullseye-slim@sha256:fab24688ec5c8cb3db76ce89f32ae9ab979bf12912789db28dd0436f6f27bb07
 
-CMD ["node", "/usr/src/app/stats.js", "/config/statsd-config.js"]
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/ /usr/src/app/
+
+EXPOSE 8126 8125/udp
+
+COPY statsd-config.js /config/statsd-config.js
+
+CMD ["/usr/local/bin/node", "/usr/src/app/stats.js", "/config/statsd-config.js"]


### PR DESCRIPTION
The `statsd` project seems dead, and its Dockerfile has not been updated for almost 2 years.

The Docker image is based on Node 12.18.3 which is past its EOL; the Node image is based on the Debian 9, which reaches its EOL on June 30, 2022. Moreover, the last 12.x Node release is 12.22.12, and 12.18.3 is pretty old (July 2020).

The original image has 5244 vulnerabilities (unknown: 11, low: 2615, medium: 1408, high: 972, critical: 238).

This PR fixes most of the vulnerabilities (77 vulnerabilities remain -- there is no fix available for them yet: Low: 61, Medium: 1, High: 12, Critical: 3).

Note that `statsd` itself has 19 vulnerabilities (6 moderate, 7 high, 6 critical).

The idea behind this PR is that we copy the installed application from the original image into a newer image (Node 16 LTS + Debian 11). 

Things are tested with the `run_tests.js` script (you may need to install python).
