### PR TITLE
InnoDB wants too much shared memory

### DIFF
--- a/mariadb-lite/Dockerfile
+++ b/mariadb-lite/Dockerfile
@@ -15,5 +15,5 @@ ENV \
     MYSQL_USER=root
 
 RUN \
-    echo '\n[mysqld]\ncollation-server = utf8_unicode_ci\ninit-connect="SET NAMES utf8"\ncharacter-set-server = utf8\ninnodb_flush_log_at_trx_commit=2\nsync_binlog=0\ninnodb_use_native_aio=0\n' >> /etc/mysql/my.cnf && \
-    echo '\n[mysqld]\ndatadir = /dev/shm/mysql\n' >> /etc/mysql/my.cnf
+    echo '\n[mysqld]\ncollation-server = utf8_unicode_ci\ninit-connect="SET NAMES utf8"\ncharacter-set-server = utf8\ninnodb_flush_log_at_trx_commit=2\nsync_binlog=0\ninnodb_use_native_aio=0\n' >> /etc/mysql/my.cnf
+#    echo '\n[mysqld]\ndatadir = /dev/shm/mysql\ninnodb_flush_method = 3\n' >> /etc/mysql/my.cnf


### PR DESCRIPTION
This causes fatal errors:

```
2022-06-20  7:31:10 0 [ERROR] InnoDB: preallocating 50331648 bytes for file ./ib_logfile1 failed with error 28
2022-06-20  7:31:10 0 [ERROR] InnoDB: Cannot set log file ./ib_logfile1 size to 50331648 bytes
2022-06-20  7:31:10 0 [ERROR] InnoDB: Database creation was aborted with error Generic error. You may need to delete the ibdata1 file before trying to start up again.
2022-06-20  7:31:10 0 [ERROR] Plugin 'InnoDB' init function returned error.
2022-06-20  7:31:10 0 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
```

This PR removes problematic settings.
