### PR TITLE
Removes the possibility of using WordPress 5.5 in dev-env

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -35,13 +35,6 @@
     "prerelease": false
   },
   {
-    "ref": "5.5.8",
-    "tag": "5.5",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
     "ref": "HEAD",
     "tag": "trunk",
     "cacheable": false,


### PR DESCRIPTION
👋 