### PR TITLE
Support mu-plugins-ext in mu-plugins image

### DIFF
--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/automattic/vip-container-images/alpine:3.16.0@sha256:65a63720c74c97
 
 RUN apk add --no-cache git && \
     git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins /mu-plugins && \
+    git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext && \
     cd /mu-plugins && \
     sed -i -e "s,git@github.com:,https://github.com/," .gitmodules && \
     git submodule update --init

--- a/mu-plugins/autoupdate.sh
+++ b/mu-plugins/autoupdate.sh
@@ -9,6 +9,7 @@ while true; do
 	if [ "$head" != "$develop" ]; then
 		git reset --hard origin/develop
 		git submodule update
+		rsync -r --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* ./
 	fi
 	# 10 mins
 	sleep 600

--- a/mu-plugins/autoupdate.sh
+++ b/mu-plugins/autoupdate.sh
@@ -9,7 +9,7 @@ while true; do
 	if [ "$head" != "$develop" ]; then
 		git reset --hard origin/develop
 		git submodule update
-		rsync -r --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* ./
+		rsync -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* ./
 	fi
 	# 10 mins
 	sleep 600

--- a/mu-plugins/run.sh
+++ b/mu-plugins/run.sh
@@ -4,7 +4,7 @@
 
 if [ ! -d /shared/.git ]; then
   rsync -a --delete --delete-delay /mu-plugins/ /shared/
-  rsync -r --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /shared
+  rsync -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /shared
   chown www-data -R /shared
 fi
 

--- a/mu-plugins/run.sh
+++ b/mu-plugins/run.sh
@@ -4,6 +4,7 @@
 
 if [ ! -d /shared/.git ]; then
   rsync -a --delete --delete-delay /mu-plugins/ /shared/
+  rsync -r --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /shared
   chown www-data -R /shared
 fi
 


### PR DESCRIPTION
# Description
We are working towards moving versioned Jetpack folders outside of mu-plugins into this mu-plugins-ext repo.

That way we can automate updates of those dependencies and combine them during deployment.