### PR TITLE
Remove WordPress version 5.6 from available versions

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -28,13 +28,6 @@
     "prerelease": false
   },
   {
-    "ref": "5.6.7",
-    "tag": "5.6",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
     "ref": "HEAD",
     "tag": "trunk",
     "cacheable": false,


### PR DESCRIPTION
This PR will effectively remove the possibility of using WordPress version 5.6 in the vip development environment.