### PR TITLE
Update node:gallium-bullseye-slim's hash

### DIFF
--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,6 +1,6 @@
 FROM statsd/statsd:v0.9.0@sha256:d7e6f2261ffeb96eff30f04c77e46959a6ddb23c492675196ceaeac5947e898c AS build
 
-FROM node:gallium-bullseye-slim@sha256:fab24688ec5c8cb3db76ce89f32ae9ab979bf12912789db28dd0436f6f27bb07
+FROM node:gallium-bullseye-slim@sha256:18ae6567b623f8c1caada3fefcc8746f8e84ad5c832abd909e129f6b13df25b4
 
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/ /usr/src/app/


### PR DESCRIPTION
This affects the `statsd` image.
