### PR TITLE
[skeleton] Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "skeleton/**"
       - ".github/workflows/skeleton.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
We need to be able to rebuild the container when Automattic/vip-go-skeleton repo changes.

For example, we had Automattic/vip-go-skeleton#89 but the image is still old.