### PR TITLE
Fix shell scripts

### DIFF
--- a/wordpress/add-version.sh
+++ b/wordpress/add-version.sh
@@ -14,25 +14,20 @@ TAG="$1"
 REF="$2"
 
 CACHEABLE=true
-if [ -n "$3" ]; then
-    if [ "$3" == "false" ]; then
-        CACHEABLE=false
-    fi
+if [ "$3" = "false" ]; then
+    CACHEABLE=false
 fi
 
 LOCKED=false
-if [ -n "$4" ]; then
-    if [ "$4" == "true" ]; then
-        LOCKED=true
-    fi
+if [ "$4" = "true" ]; then
+    LOCKED=true
 fi
 
 PRERELEASE=false
-if [ -n "$5" ]; then
-    if [ "$5" == "true" ]; then
-        PRERELEASE=true
-    fi
+if [ "$5" = "true" ]; then
+    PRERELEASE=true
 fi
+
 echo ""
 echo "Adding version: $TAG at ref: $REF"
 echo "Cacheable: $CACHEABLE"


### PR DESCRIPTION
This PR fixes the [SC3014](https://www.shellcheck.net/wiki/SC3014) "In POSIX sh, `==` in place of `=` is undefined" issue.