### PR TITLE
Add su-exec to PHP images

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -1,7 +1,7 @@
 FROM alpine:3.15@sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client php7 php7-fpm php7-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php7 php7-fpm php7-pear \
         php7-pecl-apcu \
         php7-bcmath \
         php7-calendar \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client php8 php8-fpm php8-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php8 php8-fpm php8-pear \
         php8-pecl-apcu \
         php8-bcmath \
         php8-calendar \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client php81 php81-fpm php81-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php81 php81-fpm php81-pear \
         php81-pecl-apcu \
         php81-bcmath \
         php81-calendar \


### PR DESCRIPTION
This PR adds `su-exec` (a very lightweight `sudo`) to PHP images so that we can run `wp` as `www-data` from `vip dev-env exec`.

When `wp` is run as `root`, this sometimes leads to very nice permission errors:

```
$ vip dev-env exec -- wp vip-search index --setup --skip-confirm
Adding post mapping...
Success: Mapping sent
Indexing posts...
Processed 2/2. Last Object ID: 1
Number of posts indexed: 2
Total time elapsed: 12.239
Success: Done!

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]
```

This is the first part of the fix. The second one will modify the Lando template to use `su-exec www-data:www-data wp` instead of `wp --allow-root`.
