### PR TITLE
Do not build core test images for WP older than 5.9

### DIFF
--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -5,7 +5,7 @@ COPY install-wp-core.sh /usr/local/bin/install-wp-core
 
 USER circleci
 RUN \
-	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.5")) | .[]') latest; do \
+	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.9")) | .[]') latest; do \
 		DOCKER_BUILD=1 install-wp-core "${version}"; \
 	done
 

--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -1,13 +1,12 @@
-FROM ghcr.io/automattic/vip-container-images/wp-test-base:latest@sha256:e9735c7e4928358649ce132aed353410068d8e9be4c0b4e9ea087d3091e00529
+FROM ghcr.io/automattic/vip-container-images/wp-test-base:latest@sha256:100fce8ad0fce952c3dd0e05aeb94c52c3076b691a1cbcbe523242dfe375ebab
 
 USER root
 COPY install-wp-core.sh /usr/local/bin/install-wp-core
 
 USER circleci
-RUN \
-	for version in $(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.9")) | .[]') latest; do \
-		DOCKER_BUILD=1 install-wp-core "${version}"; \
-	done
+RUN	\
+	WORDPRESS_VERSIONS="$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.9")) | .[]') latest"; \
+	for ver in ${WORDPRESS_VERSIONS}; do /usr/local/bin/install-wp-core "${ver}"; done
 
 USER root
 COPY configure-environment.sh /usr/local/bin/configure-environment

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 download_wp_core() {
 	VERSION="$1"

--- a/wp-core-test-runner/install-wp-core.sh
+++ b/wp-core-test-runner/install-wp-core.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -ex
+set -e
 
 download_wp_core() {
 	VERSION="$1"
@@ -25,23 +25,17 @@ download_wp_core() {
 		mkdir -p "/wordpress/wordpress-core-${VERSION}"
 		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}" "/wordpress/wordpress-core-${VERSION}"
 		svn co --quiet https://plugins.svn.wordpress.org/wordpress-importer/trunk/ "/wordpress/wordpress-core-${VERSION}/tests/phpunit/data/plugins/wordpress-importer"
-		(
-			cd "/wordpress/wordpress-core-${VERSION}" && \
-			composer install -n && \
-			nvm install && \
-			nvm use && \
-			npm ci && \
-			npm run build
-
-			if [ -n "${DOCKER_BUILD}" ]; then
-				rm -rf node_modules .svn
-			fi
-		)
+		cd "/wordpress/wordpress-core-${VERSION}"
+		composer install -n
+		nvm install -b
+		npm ci
+		npm run build
+		rm -rf node_modules .svn
 	else
 		echo "Skipping WordPress download"
 	fi
 }
 
 # shellcheck disable=SC1091
-[ -f "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+. "${NVM_DIR}/nvm.sh" --no-use
 download_wp_core "${1:-latest}"


### PR DESCRIPTION
We don't use those builds anyway. If we don't build it, this will reduce the size of the image, as well as its build time.