### PR TITLE
Set schedule for test runners

### DIFF
--- a/.github/workflows/wp-core-test-runner.yml
+++ b/.github/workflows/wp-core-test-runner.yml
@@ -14,6 +14,8 @@ on:
       - "wp-core-test-runner/**"
       - ".github/workflows/wp-core-test-runner.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "46 15 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/wp-test-base.yml
+++ b/.github/workflows/wp-test-base.yml
@@ -14,6 +14,8 @@ on:
       - "wp-test-base/**"
       - ".github/workflows/wp-test-base.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "39 8 * * 2"
 
 permissions:
   contents: read


### PR DESCRIPTION
* Core test runner builder needs to run on schedule to catch up with WordPress updates;
* Base test runner builder needs to run on schedule to ensure that we have current package versions
