### PR TITLE
Make the wp-core-test-runner image cache-friendly

### DIFF
--- a/.github/workflows/wp-core-test-runner.yml
+++ b/.github/workflows/wp-core-test-runner.yml
@@ -54,6 +54,12 @@ jobs:
           tags: |
             type=raw,value=latest
 
+      # Keep in sync with Dockerfile
+      - name: Get the list of WordPress versions
+        id: versions
+        run: |
+          echo ::set-output name=versions::$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.9")) | .[]' | xargs echo)
+
       - name: Build and push
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # tag=v3
         with:
@@ -61,3 +67,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: CACHE_BUSTER=${{ steps.versions.outputs.versions }}
+          cache-from: type=gha,scope=wp-core-test-runner
+          cache-to: type=gha,mode=max,scope=wp-core-test-runner

--- a/wp-core-test-runner/Dockerfile
+++ b/wp-core-test-runner/Dockerfile
@@ -1,9 +1,11 @@
+ARG CACHE_BUSTER=""
 FROM ghcr.io/automattic/vip-container-images/wp-test-base:latest@sha256:100fce8ad0fce952c3dd0e05aeb94c52c3076b691a1cbcbe523242dfe375ebab
 
 USER root
 COPY install-wp-core.sh /usr/local/bin/install-wp-core
 
 USER circleci
+# Keep in sync with wp-core-test-runner.yml
 RUN	\
 	WORDPRESS_VERSIONS="$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "5.9")) | .[]') latest"; \
 	for ver in ${WORDPRESS_VERSIONS}; do /usr/local/bin/install-wp-core "${ver}"; done


### PR DESCRIPTION
The `wp-core-test-runner` takes the most time to build. This PR makes the image more cache friendly, which helps avoid unnecessary rebuilds.
