### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get image version
         id: getversion
-        run: echo "::set-output name=version::$(head -n 1 alpine/Dockerfile | sed -e 's/FROM alpine:\(.*\)/\1/')"
+        run: echo "version=$(head -n 1 alpine/Dockerfile | sed -e 's/FROM alpine:\(.*\)/\1/')" >> $GITHUB_OUTPUT
 
       - name: Build container image
         uses: docker/build-push-action@v3

--- a/.github/workflows/mariadb-lite.yml
+++ b/.github/workflows/mariadb-lite.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get image version
         id: getversion
         run: |
-          echo "version=$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' mariadb-lite/Dockerfile)" >> $GITHUB_OUTPUT
+          echo "version=$(awk -F: '/^FROM / {print gensub(/@.+/, "", "g", $2)}' mariadb-lite/Dockerfile)" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/mariadb-lite.yml
+++ b/.github/workflows/mariadb-lite.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get image version
         id: getversion
         run: |
-          echo "::set-output name=version::$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' mariadb-lite/Dockerfile)"
+          echo "version=$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' mariadb-lite/Dockerfile)" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get image version
         id: getversion
-        run: echo "::set-output name=version::$(head -n 1 nginx/Dockerfile | sed -e 's/FROM nginx:\(.*\)-alpine/\1/')"
+        run: echo "version=$(head -n 1 nginx/Dockerfile | sed -e 's/FROM nginx:\(.*\)-alpine/\1/')" >> $GITHUB_OUTPUT
 
       - name: Build container image
         uses: docker/build-push-action@v3

--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get image version
         id: getversion
         run: |
-          echo "version=$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' statsd/Dockerfile)" >> $GITHUB_OUTPUT
+          echo "version=$(awk -F: '/^FROM / {print gensub(/@.+/, "", "g", $2);exit}' statsd/Dockerfile)" >> $GITHUB_OUTPUT
 
       - name: Build container image
         uses: docker/build-push-action@v3

--- a/.github/workflows/statsd.yml
+++ b/.github/workflows/statsd.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get image version
         id: getversion
         run: |
-          echo "::set-output name=version::$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' statsd/Dockerfile)"
+          echo "version=$(awk -F: '/^FROM / {print gensub(/\@.+/, "", "g", $2)}' statsd/Dockerfile)" >> $GITHUB_OUTPUT
 
       - name: Build container image
         uses: docker/build-push-action@v3

--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get image version
         id: getversion
-        run: echo "::set-output name=version::$(head -n 1 traefik/Dockerfile | sed -e 's/FROM traefik:\(.*\)/\1/')"
+        run: echo "version=$(head -n 1 traefik/Dockerfile | sed -e 's/FROM traefik:\(.*\)/\1/')" >> $GITHUB_OUTPUT
 
       - name: Build container image
         uses: docker/build-push-action@v3

--- a/.github/workflows/update-wp-versions.yml
+++ b/.github/workflows/update-wp-versions.yml
@@ -25,10 +25,10 @@ jobs:
         id: check-branch
         run: |
           if git ls-remote --exit-code --heads origin ${MAGIC_BRANCH_NAME}; then
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> $GITHUB_OUTPUT
             echo ::warning::"Branch '${MAGIC_BRANCH_NAME}' already exists, exiting."
           else
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
   update:
@@ -54,13 +54,13 @@ jobs:
         id: wanted
         run: |
           LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "6.0")) | .[]')
-          echo ::set-output name=latest::${LATEST}
+          echo "latest=${LATEST}" >> $GITHUB_OUTPUT
           TAGS=
           for v in ${LATEST}; do
             TAGS="${TAGS} $(echo ${v} | awk -F. '{print $1"."$2}')"
           done
           TAGS=${TAGS# }
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Remove old WordPress versions from versions.json
         run: |

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -32,7 +32,7 @@ jobs:
         id: set-matrix
         run: |
           jq -c '.' versions.json
-          echo "::set-output name=matrix::$(jq -c '.' versions.json)"
+          echo "matrix=$(jq -c '.' versions.json)" >> $GITHUB_OUTPUT
         working-directory: wordpress
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -56,9 +56,9 @@ jobs:
         id: extra-tags
         run: |
           if [ "${{ matrix.wp.locked }}" = "true" ]; then
-            echo "::set-output name=tags::ghcr.io/automattic/vip-container-images/wordpress:${{ matrix.wp.tag }}-locked"
+            echo "tags=ghcr.io/automattic/vip-container-images/wordpress:${{ matrix.wp.tag }}-locked" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tags::"
+            echo "tags=" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up QEMU


### PR DESCRIPTION
GitHub has [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` and `save-state` commands. This PR updates our workflows to use the [suggested replacement](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
