### PR TITLE
Rename vip-search -> elasticsearch

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -53,4 +53,4 @@ jobs:
           cache-to: type=gha,mode=max,scope=dev-tools
           tags: |
             ghcr.io/automattic/vip-container-images/dev-tools:latest
-            ghcr.io/automattic/vip-container-images/dev-tools:0.8
+            ghcr.io/automattic/vip-container-images/dev-tools:0.9

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -60,6 +60,10 @@ fi
 
 if [[ "$site_installed" == 0 ]]; then
   echo "No installation found, installing WordPress..."
+
+  # Ensuring wp-config-defaults is up to date
+  cp /dev-tools/wp-config-defaults.php /wp/config/
+
   if [ -n "$multisite_domain" ]; then
     wp core multisite-install \
       --path=/wp \

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -114,7 +114,7 @@ if ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {
  */
 if ( ! defined( 'VIP_ELASTICSEARCH_ENDPOINTS' ) ) {
 	define( 'VIP_ELASTICSEARCH_ENDPOINTS', [
-		'http://vip-search:9200',
+		'http://elasticsearch:9200',
 	] );
 }
 


### PR DESCRIPTION
This change
* renames expected container name `vip-search` -> `elasticsearch`
* adds reload of default config on every new install for change to take an effect
* bumps dev-tools version in order to not break old environments