### PR TITLE
Add WordPress 6.1 RC to dev-env

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -7,21 +7,21 @@
     "prerelease": false
   },
   {
-    "ref": "5.9.3",
+    "ref": "5.9.5",
     "tag": "5.9",
     "cacheable": true,
     "locked": true,
     "prerelease": false
   },
   {
-    "ref": "5.8.3",
+    "ref": "5.8.6",
     "tag": "5.8",
     "cacheable": true,
     "locked": true,
     "prerelease": false
   },
   {
-    "ref": "5.7.5",
+    "ref": "5.7.8",
     "tag": "5.7",
     "cacheable": true,
     "locked": true,

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -33,5 +33,12 @@
     "cacheable": false,
     "locked": false,
     "prerelease": true
+  },
+  {
+    "ref": "13ca93557538ede5cfd684c9c361135d6b4f2904",
+    "tag": "6.1",
+    "cacheable": true,
+    "locked": false,
+    "prerelease": true
   }
 ]


### PR DESCRIPTION
WordPress 6.1 RC2 is not available by any tag. This PR attempts to add it by using the commit hash of the 6.1 branch.