### PR TITLE
feat(php-fpm): Add `shadow` to php-fpm images

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -1,7 +1,7 @@
 FROM alpine:3.15@sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php7 php7-fpm php7-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php7 php7-fpm php7-pear \
         php7-pecl-apcu \
         php7-bcmath \
         php7-calendar \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php8 php8-fpm php8-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php8 php8-fpm php8-pear \
         php8-pecl-apcu \
         php8-bcmath \
         php8-calendar \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php81 php81-fpm php81-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php81 php81-fpm php81-pear \
         php81-pecl-apcu \
         php81-bcmath \
         php81-calendar \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -7,7 +7,7 @@ FROM alpine:edge
 
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec php82 php82-fpm php82-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php82 php82-fpm php82-pear \
         php82-pecl-apcu \
         php82-bcmath \
         php82-calendar \


### PR DESCRIPTION
This PR adds the `shadow` package to `php-fpm` images.

There main reason for doing this is that in the PHP container, we always seem to remap the `www-data` UID:

```
vip 14:40:06.INFO  ==> Making sure www-data id ('82') is correctly mapped to '1000'
vip 14:40:06.WARN  ==> User www-data is NOT correctly mapped. Will attempt to fix that.
vip 14:40:06.INFO  ==> Installing shadow to support wider uid range
vip 14:40:09.INFO  ==> Making sure group www-data exists
vip 14:40:09.WARN  ==> Group www-data doesn't exist. Will attempt to create it.
vip 14:40:09.INFO  ==> SUCCESS: group added
vip 14:40:09.INFO  ==> SUCCESS: user was added
vip 14:40:09.INFO  ==> Making www-data owner of /home/www-data
vip 14:40:09.INFO  ==> Making sure www-data id ('1000') is correctly mapped to '1000'
```

This means that we always have to install `shadow` anyway. If we do this at the image build time, we will save a couple of seconds and a bit of traffic.

PS: our custom Alpine images have `shadow` baked in; it makes sense to do the same for `php-fpm`.
