### PR TITLE
fix(dev-tools): Replace bashisms with portable code

### DIFF
--- a/dev-tools/scripts/user-container-setup.sh
+++ b/dev-tools/scripts/user-container-setup.sh
@@ -15,8 +15,10 @@
 ########################
 
 # Source log helper
+# shellcheck source=/dev/null
 . /helpers/log.sh
 
+# shellcheck disable=SC2034
 LANDO_MODULE="vip"
 
 
@@ -55,7 +57,7 @@ if [ "$LANDO_WEBROOT_UID" != "$LANDO_HOST_UID" ]; then
         exit 1;
     fi
 
-    if [[ -d "/home/$LANDO_WEBROOT_USER" ]]; then
+    if [ -d "/home/$LANDO_WEBROOT_USER" ]; then
         lando_info "Making $LANDO_WEBROOT_USER owner of /home/$LANDO_WEBROOT_USER"
         chown -R "$LANDO_WEBROOT_USER" "/home/$LANDO_WEBROOT_USER"
     fi

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -53,12 +53,7 @@ echo "Checking for WordPress installation..."
 site_exist_check_output=$(wp option get siteurl 2>&1);
 
 site_exist_return_value=$?;
-site_installed=1;
-if [[ "$site_exist_check_output" == *"The site you have requested is not installed"* ]] || echo "$site_exist_check_output" | grep -q "Site .* not found"; then
-  site_installed=0;
-fi
-
-if [[ "$site_installed" == 0 ]]; then
+if ! echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you have requested is not installed)"; then
   echo "No installation found, installing WordPress..."
 
   # Ensuring wp-config-defaults is up to date


### PR DESCRIPTION
This PR replaces several bashisms, namely:
  * In POSIX sh, [[ ]] is undefined
  * In POSIX sh, == in place of = is undefined
  * [ .. ] can't match globs. Use a case statement

in dev-tools scripts. This makes the code more portable.
