### PR TITLE
fix(gha): Fix the "Unable to process file command 'output' successfully" error

### DIFF
--- a/.github/workflows/update-wp-versions.yml
+++ b/.github/workflows/update-wp-versions.yml
@@ -54,7 +54,7 @@ jobs:
         id: wanted
         run: |
           LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "6.0")) | .[]')
-          echo "latest=${LATEST}" >> $GITHUB_OUTPUT
+          echo latest=${LATEST} >> $GITHUB_OUTPUT
           TAGS=
           for v in ${LATEST}; do
             TAGS="${TAGS} $(echo ${v} | awk -F. '{print $1"."$2}')"


### PR DESCRIPTION
Ref: https://github.com/Automattic/vip-container-images/actions/runs/3384286899/jobs/5633628321#step:4:24

```bash
$ LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "6.0")) | .[]')

$ echo "latest=${LATEST}"
latest=6.0.3
6.1

$ echo latest=${LATEST}
latest=6.0.3 6.1
```

If we quote the expression, WP versions are separated with the new line character, which upsets the runner.