### PR TITLE
feat(mu-plugins)!: Reduce the size of the image

### DIFF
--- a/.github/workflows/build-mu-plugins.yml
+++ b/.github/workflows/build-mu-plugins.yml
@@ -1,0 +1,43 @@
+name: Build MU Plugins
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - build-mu-plugins
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build MU Plugins
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container image
+        uses: docker/build-push-action@v3
+        with:
+          file: mu-plugins/Dockerfile.exp
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/automattic/vip-container-images/mu-plugins:experimental

--- a/mu-plugins/Dockerfile.exp
+++ b/mu-plugins/Dockerfile.exp
@@ -1,0 +1,16 @@
+FROM ghcr.io/automattic/vip-container-images/alpine:3.16.2@sha256:b2ef666dad5ddb75226939e2cdd3a6dbc34fbdaed4b007606641ed74fe3fa42f
+
+RUN \
+    apk add --no-cache git && \
+    git clone --depth 1 --no-remote-submodules -b staging https://github.com/Automattic/vip-go-mu-plugins /shared && \
+    git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext && \
+    cd /shared && \
+    sed -i -e "s,git@github.com:,https://github.com/," .gitmodules && \
+    git submodule update --init --recursive --depth 1 && \
+    rsync -a -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /shared && \
+    rm -rf /mu-plugins-ext && \
+    rm -rf /shared/tests /shared/__tests__ /shared/bin /shared/ci
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+CMD ["/bin/sh", "/usr/local/bin/entrypoint.sh"]

--- a/mu-plugins/entrypoint.sh
+++ b/mu-plugins/entrypoint.sh
@@ -4,4 +4,4 @@ if getent passwd www-data; then
     chown -R www-data /shared
 fi
 
-exec /bin/sleep inifinity
+exec /bin/sleep infinity

--- a/mu-plugins/entrypoint.sh
+++ b/mu-plugins/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if getent passwd www-data; then
+    chown -R www-data /shared
+fi
+
+exec /bin/sleep inifinity


### PR DESCRIPTION
This PR reduces the size of the `mu-plugins` image by keeping only one copy of the files and dropping the automatic updater.

BREAKING CHANGES:
* mu-plugins are no longer automatically updated;
* mu-plugins are built from the `staging` branch instead of `develop`.

Because `repository_dispatch` triggers can be run only from the main branch, this PR does not replace the original `Dockerfile` and tags the resulting image with the `experimental` tag. This way, we ensure that our changes do not break the dev environment, and it is still possible to test them.