### PR TITLE
ci: Add a workflow to trigger Skeleton build

### DIFF
--- a/.github/workflows/build-skeleton.yml
+++ b/.github/workflows/build-skeleton.yml
@@ -1,0 +1,44 @@
+name: Build Skeleton
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - build-skeleton
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Skeleton
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container image
+        uses: docker/build-push-action@v3
+        with:
+          context: skeleton
+          file: skeleton/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/automattic/vip-container-images/skeleton:latest

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/automattic/vip-container-images/alpine:3.16.3@sha256:1e915c312415f9347124214ba535752d83c9a3b81622c62defc02e8a1df8176a
 
 RUN apk add --no-cache --virtual build-deps git && \
-    git clone https://github.com/Automattic/vip-go-skeleton/ /clientcode && \
+    git clone --depth=1 https://github.com/Automattic/vip-go-skeleton/ /clientcode && \
     rm -rf /clientcode/.git && \
     apk del --no-cache build-deps
 


### PR DESCRIPTION
This PR adds a workflow to trigger a build of the Skeleton image.

The use case for this is when someone modifies the [automattic/vip-go-skeleton](https://github.com/Automattic/vip-go-skeleton) repository, the build is not triggered; a manual intervention is required. This has bitten us in the past.

With this workflow, it will be possible to trigger the build when the `vip-go-skeleton` repository has been pushed to.
