### PR TITLE
WordPress: Update 6.1 to 6.1.1 and sort the versions in CI

### DIFF
--- a/.github/workflows/update-wp-versions.yml
+++ b/.github/workflows/update-wp-versions.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get WordPress versions we want
         id: wanted
         run: |
-          LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "6.0")) | .[]')
+          LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq -r '[.offers[].version] | unique | map(select( . >= "6.0")) | sort | reverse | .[]')
           echo latest=${LATEST} >> $GITHUB_OUTPUT
           TAGS=
           for v in ${LATEST}; do

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,6 +1,6 @@
 [
   {
-    "ref": "6.1",
+    "ref": "6.1.1",
     "tag": "6.1",
     "cacheable": true,
     "locked": true,


### PR DESCRIPTION
- Add 6.1.1 
- Workaround a bug in the CI workflow that listed version tags as  as 6.0 6.1 6.1 for 6.0, 6.1, 6.1.1)

```
Adding version: 6.0 at ref: 6.0.3
Cacheable: true
Locked: true
Prerelease: false

Adding version: 6.1 at ref: 6.1
Cacheable: true
Locked: true
Prerelease: false

Adding version: 6.1 at ref: 6.1.1
Cacheable: true
Locked: true
Prerelease: false
6.1 already exists in versions.json
```

I feel like there's still opportunity for improvement, but it's good enough for now :)
