### PR TITLE
chore(deps): Update Alpine hashes

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -1,4 +1,4 @@
-FROM alpine:3.15@sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22
+FROM alpine:3.15@sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479
 
 RUN \
     apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php7 php7-fpm php7-pear \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
+FROM alpine:3.16.3@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
 
 RUN \
     apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php8 php8-fpm php8-pear \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
+FROM alpine:3.16.3@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
 
 RUN \
     apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php81 php81-fpm php81-pear \


### PR DESCRIPTION
Dependabot fails miserably here, we have to do the update manually.

The most recent version of Alpine 3.15 is `cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479` (3.15.6)
The most recent version of Alpine 3.16 is `b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b` (3.16.3)

Both were released a week ago.