### PR TITLE
feat(php-fpm): Add support for MailHog

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -1,7 +1,7 @@
 FROM alpine:3.15@sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php7 php7-fpm php7-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow jq php7 php7-fpm php7-pear \
         php7-pecl-apcu \
         php7-bcmath \
         php7-calendar \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -1,7 +1,7 @@
 FROM alpine:3.16.3@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php8 php8-fpm php8-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow jq php8 php8-fpm php8-pear \
         php8-pecl-apcu \
         php8-bcmath \
         php8-calendar \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,7 +1,7 @@
 FROM alpine:3.16.3@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
 
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php81 php81-fpm php81-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow jq php81 php81-fpm php81-pear \
         php81-pecl-apcu \
         php81-bcmath \
         php81-calendar \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -7,7 +7,7 @@ FROM alpine:edge
 
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
-    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow php82 php82-fpm php82-pear \
+    apk add --no-cache ca-certificates curl tar xz openssl less bash mariadb-client su-exec shadow jq php82 php82-fpm php82-pear \
         php82-pecl-apcu \
         php82-bcmath \
         php82-calendar \

--- a/php-fpm/rootfs74/usr/local/bin/run.sh
+++ b/php-fpm/rootfs74/usr/local/bin/run.sh
@@ -11,4 +11,10 @@ else
     rm -f $XDEBUG_CONFIG_TARGET_LOCATION
 fi
 
+if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+else
+    rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+fi
+
 exec /usr/sbin/php-fpm7

--- a/php-fpm/rootfs80/usr/local/bin/run.sh
+++ b/php-fpm/rootfs80/usr/local/bin/run.sh
@@ -11,4 +11,10 @@ else
     rm -f $XDEBUG_CONFIG_TARGET_LOCATION
 fi
 
+if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+else
+    rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+fi
+
 exec /usr/sbin/php-fpm8

--- a/php-fpm/rootfs81/usr/local/bin/run.sh
+++ b/php-fpm/rootfs81/usr/local/bin/run.sh
@@ -11,4 +11,10 @@ else
     rm -f $XDEBUG_CONFIG_TARGET_LOCATION
 fi
 
+if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+else
+    rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+fi
+
 exec /usr/sbin/php-fpm81

--- a/php-fpm/rootfs82/usr/local/bin/run.sh
+++ b/php-fpm/rootfs82/usr/local/bin/run.sh
@@ -11,4 +11,10 @@ else
     rm -f $XDEBUG_CONFIG_TARGET_LOCATION
 fi
 
+if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port'):1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+else
+    rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+fi
+
 exec /usr/sbin/php-fpm82


### PR DESCRIPTION
This PR‌ adds support for MailHog into PHP-FPM images.

The presence of MailHog is detected from the `LANDO_INFO` environment variable. If MailHog is detected, the startup script updates the `sendmail_path` to use the MailHog service.
