### PR TITLE
fix(dev-tools): Remove all traces of statsd

### DIFF
--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -127,22 +127,6 @@ if ( ! defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) {
 }
 
 /**
- * StatsD
- */
-
-if ( ! defined( 'VIP_DISABLE_STATSD' ) ) {
-	define( 'VIP_DISABLE_STATSD', getenv( 'STATSD' ) === 'disable' );
-}
-
-if ( ! defined( 'VIP_STATSD_HOST' ) ) {
-	define( 'VIP_STATSD_HOST', 'statsd' );
-}
-
-if ( ! defined( 'VIP_STATSD_PORT' ) ) {
-	define( 'VIP_STATSD_PORT', 8126 );
-}
-
-/**
  * Needed for local SSL setup
  */
 if ( ! defined( 'FORCE_SSL_ADMIN' ) ) {


### PR DESCRIPTION
This PR removes statsd-related constants from wp-config-defaults.php.
