### PR TITLE
fix(wordpress): Add placement anchor to wp-config.php

### DIFF
--- a/wordpress/extra/wp-config.php
+++ b/wordpress/extra/wp-config.php
@@ -4,7 +4,7 @@ require( dirname( __FILE__ ) . '/config/wp-config.php' );
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */
-if ( !defined('ABSPATH') ) {
+if ( ! defined( 'ABSPATH' ) ) {
     define('ABSPATH', dirname(__FILE__) . '/');
 }
 

--- a/wordpress/extra/wp-config.php
+++ b/wordpress/extra/wp-config.php
@@ -5,7 +5,7 @@ require( dirname( __FILE__ ) . '/config/wp-config.php' );
 
 /** Absolute path to the WordPress directory. */
 if ( ! defined( 'ABSPATH' ) ) {
-    define('ABSPATH', dirname(__FILE__) . '/');
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 
 /** Sets up WordPress vars and included files. */

--- a/wordpress/extra/wp-config.php
+++ b/wordpress/extra/wp-config.php
@@ -1,4 +1,12 @@
 <?php
 
 require( dirname( __FILE__ ) . '/config/wp-config.php' );
+/* That's all, stop editing! Happy blogging. */
+/** Absolute path to the WordPress directory. */
+if ( !defined('ABSPATH') ) {
+	define('ABSPATH', dirname(__FILE__) . '/');
+}
+
+/** Sets up WordPress vars and included files. */
+
 require_once( ABSPATH . 'wp-settings.php' );

--- a/wordpress/extra/wp-config.php
+++ b/wordpress/extra/wp-config.php
@@ -5,7 +5,7 @@ require( dirname( __FILE__ ) . '/config/wp-config.php' );
 
 /** Absolute path to the WordPress directory. */
 if ( !defined('ABSPATH') ) {
-	define('ABSPATH', dirname(__FILE__) . '/');
+    define('ABSPATH', dirname(__FILE__) . '/');
 }
 
 /** Sets up WordPress vars and included files. */

--- a/wordpress/extra/wp-config.php
+++ b/wordpress/extra/wp-config.php
@@ -2,11 +2,11 @@
 
 require( dirname( __FILE__ ) . '/config/wp-config.php' );
 /* That's all, stop editing! Happy blogging. */
+
 /** Absolute path to the WordPress directory. */
 if ( !defined('ABSPATH') ) {
 	define('ABSPATH', dirname(__FILE__) . '/');
 }
 
 /** Sets up WordPress vars and included files. */
-
 require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
This PR adds the placement anchor to `wp-config.php` so that `wp config set` command works.

Without the anchor, it fails with
```
Error: Could not process the 'wp-config.php' transformation.
Reason: Unable to locate placement anchor.
```
