### PR TITLE
feat(dev-tools): Automatically activate ES when dev-env has elasticsearch and uses the demo app code image

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -97,6 +97,14 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
   if [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ] && [ "$(echo "${LANDO_INFO}" | jq .demo-app-code.service)" != 'null' ]; then
     wp config set VIP_ENABLE_VIP_SEARCH true --raw
     wp config set VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION true --raw
+    echo "To disable the VIP Search integration, please run:"
+    if [ -n "${LANDO_APP_NAME}" ]; then
+      echo "vip dev-env exec --slug ${LANDO_APP_NAME} -- wp config delete VIP_ENABLE_VIP_SEARCH"
+      echo "vip dev-env exec --slug ${LANDO_APP_NAME} -- wp config delete VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION"
+    else
+      echo "wp config delete VIP_ENABLE_VIP_SEARCH"
+      echo "wp config delete VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION"
+    fi
   fi
 
   if wp cli has-command vip-search; then

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -97,7 +97,8 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
   if [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ] && [ "$(echo "${LANDO_INFO}" | jq .demo-app-code.service)" != 'null' ]; then
     wp config set VIP_ENABLE_VIP_SEARCH true --raw
     wp config set VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION true --raw
-    echo "To disable the VIP Search integration, please run:"
+    echo "Automatically set constants VIP_ENABLE_VIP_SEARCH and VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION to true. For more information, see https://docs.wpvip.com/how-tos/vip-search/enable/"
+    echo "To disable the Enterprise Search integration, please run:"
     if [ -n "${LANDO_APP_NAME}" ]; then
       echo "vip dev-env exec --slug ${LANDO_APP_NAME} -- wp config delete VIP_ENABLE_VIP_SEARCH"
       echo "vip dev-env exec --slug ${LANDO_APP_NAME} -- wp config delete VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION"

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -94,6 +94,11 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
       --skip-plugins #2>/dev/null
   fi
 
+  if [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ] && [ "$(echo "${LANDO_INFO}" | jq .demo-app-code.service)" != 'null' ]; then
+    wp config set VIP_ENABLE_VIP_SEARCH true --raw
+    wp config set VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION true --raw
+  fi
+
   if wp cli has-command vip-search; then
     wp vip-search index --skip-confirm --setup
   fi


### PR DESCRIPTION
This PR updates the setup script so that it activates ES features by defining `VIP_ENABLE_VIP_SEARCH` and `VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION` to `true` when
1. The dev env has the ElasticSearch enabled
2. The dev env sources the application code from an image

This saves the user a couple of calls to `vip dev-env exec -- wp config set ...` and `vip dev-env exec -- wp vip-search index --setup`.

⚠️ #391 needs ti be merged and built first, because it contains an import bugfix this PR relies upon.
