### PR TITLE
fix(dev-tools): Wait for ES to come online before trying to contact it

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -109,6 +109,16 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
   fi
 
   if wp cli has-command vip-search; then
+    echo "Waiting for ElasticSearch to come online..."
+    second=0
+    while [ "$(curl -s http://elasticsearch:9200/_cluster/health | jq -r .status)" != 'green' ] && [ "${second}" -lt 60 ]; do
+      sleep 1
+      second=$((second+1))
+    done
+    if [ "$(curl -s http://elasticsearch:9200/_cluster/health | jq -r .status)" != 'green' ]; then
+        echo "WARNING: ElasticSearch has failed to come online"
+    fi
+
     wp vip-search index --skip-confirm --setup
   fi
 


### PR DESCRIPTION
Until https://github.com/Automattic/vip-cli/pull/1229 is deployed, we have to check whether ES is already online before trying to contact it. Otherwise, post mapping might fail.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/3849360436/jobs/6558708351#step:13:225
