### PR TITLE
ci(traefic_openssl): Tag the image as `latest`

### DIFF
--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -57,3 +57,4 @@ jobs:
           cache-to: type=gha,mode=max,scope=traefik
           tags: |
             ghcr.io/automattic/vip-container-images/traefik_openssl:${{ steps.getversion.outputs.version }}
+            ghcr.io/automattic/vip-container-images/traefik_openssl:latest


### PR DESCRIPTION
So that we don't have to update Lando every time there is new release of traefik.
