### PR TITLE
feat(dev-tools): Add env var to enable ES

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -59,7 +59,7 @@ fi
 echo "Copying dev-env-plugin.php to mu-plugins"
 cp /dev-tools/dev-env-plugin.php /wp/wp-content/mu-plugins/
 
-if [ -n "${LANDO_INFO}" ] && [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ]; then
+if [ -n "${ENABLE_ELASTICSEARCH}" ] || { [ -n "${LANDO_INFO}" ] && [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ]; }; then
   echo "Waiting for Elasticsearch to come online..."
   second=0
   while [ "$(curl -s http://elasticsearch:9200/_cluster/health | jq -r .status)" != 'green' ] && [ "${second}" -lt 60 ]; do


### PR DESCRIPTION
Currently, `setup.sh` relies upon the `LANDO_INFO` environment variable to find out whether ES is enabled.

This PR adds another var, `ENABLE_ELASTICSEARCH`, to allow this container to be used in Landoless environments like Codespaces.