### PR TITLE
feat(php-fpm): Add env var to enable MailHog

### DIFF
--- a/php-fpm/rootfs74/usr/local/bin/run.sh
+++ b/php-fpm/rootfs74/usr/local/bin/run.sh
@@ -13,6 +13,8 @@ fi
 
 if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
     echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+elif [ -n "${ENABLE_MAILHOG}" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S mailhog:1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 else
     rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 fi

--- a/php-fpm/rootfs80/usr/local/bin/run.sh
+++ b/php-fpm/rootfs80/usr/local/bin/run.sh
@@ -13,6 +13,8 @@ fi
 
 if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
     echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+elif [ -n "${ENABLE_MAILHOG}" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S mailhog:1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 else
     rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 fi

--- a/php-fpm/rootfs81/usr/local/bin/run.sh
+++ b/php-fpm/rootfs81/usr/local/bin/run.sh
@@ -13,6 +13,8 @@ fi
 
 if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
     echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port')" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+elif [ -n "${ENABLE_MAILHOG}" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S mailhog:1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 else
     rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 fi

--- a/php-fpm/rootfs82/usr/local/bin/run.sh
+++ b/php-fpm/rootfs82/usr/local/bin/run.sh
@@ -13,6 +13,8 @@ fi
 
 if [ -n "${LANDO_INFO}" ] && [ 'null' != "$(echo "${LANDO_INFO}" | jq -r .mailhog)" ]; then
     echo "sendmail_path = /usr/sbin/sendmail -S $(echo "${LANDO_INFO}" | jq -r '.mailhog.internal_connection.host + ":" + .mailhog.internal_connection.port'):1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
+elif [ -n "${ENABLE_MAILHOG}" ]; then
+    echo "sendmail_path = /usr/sbin/sendmail -S mailhog:1025" > "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 else
     rm -f "${PHP_INI_DIR}/conf.d/99-mailhog.ini"
 fi


### PR DESCRIPTION
Currently, the startiup script relies upon the `LANDO_INFO` environment variable to find out whether MailHog is enabled.

This PR adds another var, `ENABLE_MAILHOG`, to allow this container to be used in Landoless environments like Codespaces.