### PR TITLE
feat: Add shadow package

### DIFF
--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/automattic/vip-container-images/alpine:3.17.1@sha256:fbd2cb3cd937080dd4a701d0433e7b0604260e3542a805cef815790e2f921ebf
 
 RUN \
-    apk add --no-cache git && \
+    apk add --no-cache git shadow && \
     git clone --depth 1 --no-remote-submodules -b staging https://github.com/Automattic/vip-go-mu-plugins /shared && \
     git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext && \
     cd /shared && \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.23.3-alpine@sha256:659610aadb34b7967dea7686926fdcf08d588a71c5121edb094ce0e4cdbc45e6
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl shadow
 
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -18,4 +18,5 @@ RUN \
 COPY extra/ /wordpress/wordpress/
 
 FROM ghcr.io/automattic/vip-container-images/alpine:3.17.1@sha256:fbd2cb3cd937080dd4a701d0433e7b0604260e3542a805cef815790e2f921ebf
+RUN apk add --no-cache shadow
 COPY --from=build /wordpress/wordpress/ /wp/


### PR DESCRIPTION
This PR adds `shadow` package to `wordpress`, `nginx`, and `mu-plugins`.

Specifically, we will need `usermod` and `groupmod` to update UID/GID in Landoless environments.
