### PR TITLE
refactor(dev-tools): Improve ES health check

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -63,7 +63,7 @@ if [ -n "${LANDO_INFO}" ] && [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.servi
   echo "Waiting for Elasticsearch to come online..."
   status="$(curl -s 'http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=60' | jq -r .status)"
   if [ "${status}" != 'green' ] && [ "${status}" != 'yellow' ]; then
-      echo "WARNING: ElasticSearch has failed to come online"
+      echo "WARNING: Elasticsearch has failed to come online"
   fi
 fi
 

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -61,12 +61,8 @@ cp /dev-tools/dev-env-plugin.php /wp/wp-content/mu-plugins/
 
 if [ -n "${LANDO_INFO}" ] && [ "$(echo "${LANDO_INFO}" | jq .elasticsearch.service)" != 'null' ]; then
   echo "Waiting for Elasticsearch to come online..."
-  second=0
-  while [ "$(curl -s http://elasticsearch:9200/_cluster/health | jq -r .status)" != 'green' ] && [ "${second}" -lt 60 ]; do
-    sleep 1
-    second=$((second+1))
-  done
-  if [ "$(curl -s http://elasticsearch:9200/_cluster/health | jq -r .status)" != 'green' ]; then
+  status="$(curl -s 'http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=60' | jq -r .status)"
+  if [ "${status}" != 'green' ] && [ "${status}" != 'yellow' ]; then
       echo "WARNING: ElasticSearch has failed to come online"
   fi
 fi


### PR DESCRIPTION
Use `wait_for_status` and `timeout` instead of a loop. Also, accept `yellow` status as OK.