### PR TITLE
fix(dev-env): Add code to wait for mu-plugins to become ready

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -25,6 +25,16 @@ do
   fi
 done
 
+echo 'Waiting for mu-plugins...'
+i=0;
+while [ ! -f /wp/wp-content/mu-plugins/000-vip-init.php ]; do
+  sleep 1
+  i=$((i+1))
+  if [ $i -eq 60 ]; then
+    echo "ERROR: mu-plugins not found. Please try to restart or destroy the environment"
+    exit 1;
+  fi
+done
 
 if [ -r /wp/config/wp-config.php ]; then
   echo "Already existing wp-config.php file"


### PR DESCRIPTION
This PR adds a code to wait for `mu-plugins` become ready to avoid some unpleasant races.