### PR TITLE
Add welcome banner and improve terminal prompt for PHP-FPM containers

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -64,6 +64,7 @@ RUN \
 ENV WP_CLI_CONFIG_PATH /config/wp-cli.yaml
 ENV PHP_INI_DIR /etc/php7
 
+COPY rootfs-common/ /
 COPY rootfs74/ /
 
 WORKDIR /var/www/html

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -66,7 +66,9 @@ RUN \
 ENV WP_CLI_CONFIG_PATH /config/wp-cli.yaml
 ENV PHP_INI_DIR /etc/php8
 
+COPY rootfs-common/ /
 COPY rootfs80/ /
+
 
 WORKDIR /var/www/html
 STOPSIGNAL SIGQUIT

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -71,6 +71,7 @@ RUN \
 ENV WP_CLI_CONFIG_PATH /config/wp-cli.yaml
 ENV PHP_INI_DIR /etc/php81
 
+COPY rootfs-common/ /
 COPY rootfs81/ /
 COPY --from=build /usr/lib/php81/modules/gmagick.so /usr/lib/php81/modules/
 

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -75,6 +75,7 @@ RUN \
 ENV WP_CLI_CONFIG_PATH /config/wp-cli.yaml
 ENV PHP_INI_DIR /etc/php82
 
+COPY rootfs-common/ /
 COPY rootfs82/ /
 COPY --from=build /usr/lib/php82/modules/memcache.so /usr/lib/php82/modules/gmagick.so /usr/lib/php82/modules/
 

--- a/php-fpm/rootfs-common/etc/vip-motd
+++ b/php-fpm/rootfs-common/etc/vip-motd
@@ -1,0 +1,10 @@
+
+＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/
+＿/　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 ＿/
+＿/　 Welcome to VIP Local Development Environment!　 ＿/
+＿/　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 ＿/
+＿/　 Learn more at: https://docs.wpvip.com 　 　 　  ＿/
+＿/　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 　 ＿/
+＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/＿/
+
+

--- a/php-fpm/rootfs-common/home/www-data/.bashrc
+++ b/php-fpm/rootfs-common/home/www-data/.bashrc
@@ -1,0 +1,6 @@
+cat /etc/vip-motd
+
+echo "You're using interactive shell for $LANDO_APP_NAME"
+echo ""
+echo ""
+PS1='\[\033[01;32m\]\u\[\033[01;34m\]:\w \$\[\033[00m\] '

--- a/php-fpm/rootfs-common/root/.bashrc
+++ b/php-fpm/rootfs-common/root/.bashrc
@@ -1,0 +1,6 @@
+cat /etc/vip-motd
+
+echo "You're using interactive shell for $LANDO_APP_NAME"
+echo ""
+echo ""
+PS1='\[\033[01;32m\]\u\[\033[01;34m\]:\w \$\[\033[00m\] '


### PR DESCRIPTION
Previously when logging onto container we saw the default `bash-5.1# ` prompt. Now we'll display a banner and modify the prompt to be more descriptive - it'll show the user and the current working directory. 

![image](https://user-images.githubusercontent.com/459254/215957082-ec6380c9-7a3e-49ba-89b8-7887b4351c9e.png)


We added a new folder rootfs-common, that will contain anything that needs to be shared across different image version.

