### PR TITLE
fix(dev-tools): Support MySQL 8 syntax for creating users

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -61,8 +61,10 @@ fi
 echo "Checking for database connectivity..."
 if ! mysql -h "$db_host" -u wordpress -pwordpress wordpress -e "SELECT 'testing_db'" >/dev/null 2>&1; then
   echo "No WordPress database exists, provisioning..."
-  echo "GRANT ALL ON *.* TO 'wordpress'@'localhost' IDENTIFIED BY 'wordpress' WITH GRANT OPTION;" | mysql -h "$db_host" -u "$db_admin_user"
-  echo "GRANT ALL ON *.* TO 'wordpress'@'%' IDENTIFIED BY 'wordpress' WITH GRANT OPTION;" | mysql -h "$db_host" -u "$db_admin_user"
+  echo "CREATE USER IF NOT EXISTS 'wordpress'@'localhost' IDENTIFIED BY 'wordpress'" | mysql -h "$db_host" -u "$db_admin_user"
+  echo "CREATE USER IF NOT EXISTS 'wordpress'@'%' IDENTIFIED BY 'wordpress'" | mysql -h "$db_host" -u "$db_admin_user"
+  echo "GRANT ALL ON *.* TO 'wordpress'@'localhost' WITH GRANT OPTION;" | mysql -h "$db_host" -u "$db_admin_user"
+  echo "GRANT ALL ON *.* TO 'wordpress'@'%' WITH GRANT OPTION;" | mysql -h "$db_host" -u "$db_admin_user"
   echo "CREATE DATABASE wordpress;" | mysql -h "$db_host" -u "$db_admin_user"
 fi
 


### PR DESCRIPTION
> In MySQL 8.0, you must create a user first before assigning permission, as the GRANT command will no longer create a new user.