### PR TITLE
fix(dev-tools): Fix Host header for Codespaces

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -1,5 +1,8 @@
 <?php
 
+if ( isset( $_SERVER['CODESPACES'] ) && 'true' === $_SERVER['CODESPACES'] && ! empty( $_SERVER['HTTP_X_FORWARDED_HOST'] ) ) {
+	$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+}
 
 /******************
  * Handle HTTPS


### PR DESCRIPTION
This PR updates `$_SERVER['HTTP_HOST']` to match the real hostname of the codespace.