### PR TITLE
fix(dev-tools): Check for `.version` only if `mu-plugins` is a mount point

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -25,16 +25,18 @@ do
   fi
 done
 
-echo 'Waiting for mu-plugins...'
-i=0;
-while [ ! -f /wp/wp-content/mu-plugins/.version ]; do
-  sleep 1
-  i=$((i+1))
-  if [ $i -eq 60 ]; then
-    echo "ERROR: mu-plugins not found. Please try to restart or destroy the environment"
-    exit 1;
-  fi
-done
+if mountpoint -q /wp/wp-content/mu-plugins; then
+  echo 'Waiting for mu-plugins...'
+  i=0;
+  while [ ! -f /wp/wp-content/mu-plugins/.version ]; do
+    sleep 1
+    i=$((i+1))
+    if [ $i -eq 60 ]; then
+      echo "ERROR: mu-plugins not found. Please try to restart or destroy the environment"
+      exit 1;
+    fi
+  done
+fi
 
 if [ -r /wp/config/wp-config.php ]; then
   echo "Already existing wp-config.php file"


### PR DESCRIPTION
Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/4294727373/jobs/7485334888