### PR TITLE
Object-cache: Define WPMU_PLUGIN_DIR if undefined

### DIFF
--- a/wordpress/extra/wp-content/object-cache.php
+++ b/wordpress/extra/wp-content/object-cache.php
@@ -11,6 +11,10 @@
  * This file is require'd from wp-content/object-cache.php
  */
 
+ if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+	define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' );
+}
+
 $mu_plugins_file = ABSPATH . '/wp-content/mu-plugins/drop-ins/object-cache.php';
 if ( file_exists( $mu_plugins_file ) ) {
 	require_once $mu_plugins_file;


### PR DESCRIPTION
If we were to go back to `2f0b6ca496182e18e7296b57c9dbc17ff237504c` for `vip-go-mu-plugins`: https://github.com/Automattic/vip-go-mu-plugins/blob/2f0b6ca496182e18e7296b57c9dbc17ff237504c/drop-ins/object-cache.php#L3-L4

We would get a fatal:

```
[07-Mar-2023 18:35:37 UTC] PHP Fatal error:  Uncaught Error: Undefined constant "WPMU_PLUGIN_DIR" in /wp/wp-content/mu-plugins/drop-ins/object-cache.php:4
Stack trace:
#0 /wp/wp-content/object-cache.php(16): require_once()
#1 /wp/wp-includes/load.php(695): require_once('/wp/wp-content/...')
#2 /wp/wp-settings.php(131): wp_start_object_cache()
#3 /wp/wp-config.php(12): require_once('/wp/wp-settings...')
#4 /wp/wp-load.php(50): require_once('/wp/wp-config.p...')
#5 /wp/wp-blog-header.php(13): require_once('/wp/wp-load.php')
#6 /wp/index.php(17): require('/wp/wp-blog-hea...')
#7 {main}
  thrown in /wp/wp-content/mu-plugins/drop-ins/object-cache.php on line 4
```