### PR TITLE
fix(dev-tools): Fix detection of GitHub Codespaces

### DIFF
--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -6,8 +6,9 @@
 /**
  * Adjust HTTP_HOST for GitHub Codespaces.
  */
-if ( isset( $_SERVER['CODESPACES'] ) && 'true' === $_SERVER['CODESPACES'] && ! empty( $_SERVER['HTTP_X_FORWARDED_HOST'] ) ) {
+if ( ! empty( $_SERVER['HTTP_X_FORWARDED_HOST'] ) && substr( $_SERVER['HTTP_X_FORWARDED_HOST'], -strlen( '.github.dev' ) ) === '.github.dev' ) {
 	$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+	$_ENV['HTTP_HOST']    = $_SERVER['HTTP_HOST'];
 }
 
 /**


### PR DESCRIPTION
GitHub no longer exposes `$_SERVER['CODESPACES']`, so we have to go another way.
