### PR TITLE
fix: Skip themes on WP install

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -101,6 +101,7 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
       --admin_email="vip@localhost.local" \
       --admin_password="password" \
       --skip-email \
+      --skip-themes \
       --skip-plugins \
       --subdomains \
       --skip-config #2>/dev/null
@@ -113,6 +114,7 @@ if echo "$site_exist_check_output" | grep -Eq "(Site .* not found)|(The site you
       --admin_email="vip@localhost.local" \
       --admin_password="password" \
       --skip-email \
+      --skip-themes \
       --skip-plugins #2>/dev/null
   fi
 


### PR DESCRIPTION
Related: https://github.com/Automattic/vip-go-mu-plugins/pull/4247

Do not load themes for `wp core install` to ensure that user code does not interfere with the process.
