### PR TITLE
Adds autologin support

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -97,3 +97,19 @@ function dev_env_add_admin( $args, $assoc_args ) {
 		}
 	}
 }
+
+// Login the user automatically
+add_action('init', 'dev_env_auto_login');
+function dev_env_auto_login()
+{
+	// Check if the user is not already logged in and the query parameter exists
+	if (!is_user_logged_in() && isset($_GET['vip-dev-autologin'])) {
+		$user = get_user_by('login', 'vipgo');
+		wp_set_current_user($user->ID, $user->user_login);
+		wp_set_auth_cookie($user->ID);
+		do_action('wp_login', $user->user_login, $user);
+
+		wp_redirect(admin_url());
+		exit;
+	}
+}

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -125,6 +125,6 @@ function dev_env_auto_login() {
 	wp_set_auth_cookie( $user->ID );
 	do_action( 'wp_login', $user->user_login, $user );
 
-	wp_redirect( admin_url() );
+	wp_safe_redirect( admin_url() );
 	exit;
 }

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -117,6 +117,10 @@ function dev_env_auto_login() {
 	}
 
 	$user = get_user_by( 'login', 'vipgo' );
+	if ( ! $user ) {
+		return;
+	}
+
 	wp_set_current_user( $user->ID, $user->user_login );
 	wp_set_auth_cookie( $user->ID );
 	do_action( 'wp_login', $user->user_login, $user );

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -107,12 +107,12 @@ function dev_env_auto_login() {
 		return;
 	}
 
-	$expectd_key = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ?? false;
-	if ( ! $expectd_key ) {
+	$expected_key = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ?? false;
+	if ( ! $expected_key ) {
 		return;
 	}
 	$submitted_key = $_GET['vip-dev-autologin'] ?? false;
-	if ( $submitted_key !== $expectd_key ) {
+	if ( $submitted_key !== $expected_key ) {
 		return;
 	}
 

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -103,15 +103,24 @@ function dev_env_auto_login() {
 	if ( 'local' !== VIP_GO_APP_ENVIRONMENT ) {
 		return;
 	}
-
-	// Check if the user is not already logged in and the query parameter exists
-	if ( ! is_user_logged_in() && isset( $_GET['vip-dev-autologin'] ) ) {
-		$user = get_user_by( 'login', 'vipgo' );
-		wp_set_current_user( $user->ID, $user->user_login );
-		wp_set_auth_cookie( $user->ID );
-		do_action( 'wp_login', $user->user_login, $user );
-
-		wp_redirect( admin_url() );
-		exit;
+	if ( is_user_logged_in() ) {
+		return;
 	}
+
+	$expectd_key = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ?? false;
+	if ( ! $expectd_key ) {
+		return;
+	}
+	$submitted_key = $_GET['vip-dev-autologin'] ?? false;
+	if ( $submitted_key !== $expectd_key ) {
+		return;
+	}
+
+	$user = get_user_by( 'login', 'vipgo' );
+	wp_set_current_user( $user->ID, $user->user_login );
+	wp_set_auth_cookie( $user->ID );
+	do_action( 'wp_login', $user->user_login, $user );
+
+	wp_redirect( admin_url() );
+	exit;
 }

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -5,7 +5,7 @@
  ******************/
 
 add_filter( 'set_url_scheme', function( $url ) {
-	$proto = $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ?? '';
+	$proto = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '';
 
 	if ( 'https' == $proto ) {
 		return str_replace( 'http://', 'https://', $url );
@@ -67,7 +67,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 function dev_env_add_admin( $args, $assoc_args ) {
 	$username = $assoc_args['username'] ?? '';
 	$password = $assoc_args['password'] ?? '';
-	$email = $assoc_args['email'] ?? $username . '@go-vip.net';
+	$email    = $assoc_args['email'] ?? $username . '@go-vip.net';
 
 	if ( ! $username || ! $password ) {
 		WP_CLI::error( 'Both username and password need to be provided!' );
@@ -98,18 +98,20 @@ function dev_env_add_admin( $args, $assoc_args ) {
 	}
 }
 
-// Login the user automatically
-add_action('init', 'dev_env_auto_login');
-function dev_env_auto_login()
-{
-	// Check if the user is not already logged in and the query parameter exists
-	if (!is_user_logged_in() && isset($_GET['vip-dev-autologin'])) {
-		$user = get_user_by('login', 'vipgo');
-		wp_set_current_user($user->ID, $user->user_login);
-		wp_set_auth_cookie($user->ID);
-		do_action('wp_login', $user->user_login, $user);
+add_action( 'init', 'dev_env_auto_login' );
+function dev_env_auto_login() {
+	if ( 'local' !== VIP_GO_APP_ENVIRONMENT ) {
+		return;
+	}
 
-		wp_redirect(admin_url());
+	// Check if the user is not already logged in and the query parameter exists
+	if ( ! is_user_logged_in() && isset( $_GET['vip-dev-autologin'] ) ) {
+		$user = get_user_by( 'login', 'vipgo' );
+		wp_set_current_user( $user->ID, $user->user_login );
+		wp_set_auth_cookie( $user->ID );
+		do_action( 'wp_login', $user->user_login, $user );
+
+		wp_redirect( admin_url() );
 		exit;
 	}
 }

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -107,7 +107,7 @@ function dev_env_auto_login() {
 		return;
 	}
 
-	$expected_key = getenv( 'VIP_DEV_AUTOLOGIN_KEY' ) ?? false;
+	$expected_key = getenv( 'VIP_DEV_AUTOLOGIN_KEY' );
 	if ( ! $expected_key ) {
 		return;
 	}


### PR DESCRIPTION
This adds support for dev-env to autologin with clicking a link (One-click login).

The CLI counterpart to this is - https://github.com/Automattic/vip-cli/pull/1317

The only requirement is to have `vip-dev-autologin` as query parameter.

The next step is to include this link to the info table on environment startup:

http://vip-local.vipdev.lndo.site/wp-admin/?vip-dev-autologin

This will login users directly.

Props to @rinatkhaziev for inspiration

**EDIT**

After few iterations we decided to step up the security around this change. Now there is a unique unlock key which is generated on dev-env creation/update and injected as an environment variable. At the same time this key is shown to users in cli when starting the environment.

![Autologin](https://user-images.githubusercontent.com/19240162/228779286-b9879d92-3c1a-4918-9ead-25ed12ceda62.gif)
