### PR TITLE
Add xdebug config - discover_client_host

### DIFF
--- a/php-fpm/rootfs74/etc/php7/conf.d/xdebug.ini.template
+++ b/php-fpm/rootfs74/etc/php7/conf.d/xdebug.ini.template
@@ -8,3 +8,4 @@ xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 
 xdebug.log=/tmp/xdebug.log
+xdebug.discover_client_host=true

--- a/php-fpm/rootfs80/etc/php8/conf.d/xdebug.ini.template
+++ b/php-fpm/rootfs80/etc/php8/conf.d/xdebug.ini.template
@@ -8,3 +8,4 @@ xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 
 xdebug.log=/tmp/xdebug.log
+xdebug.discover_client_host=true

--- a/php-fpm/rootfs81/etc/php81/conf.d/xdebug.ini.template
+++ b/php-fpm/rootfs81/etc/php81/conf.d/xdebug.ini.template
@@ -8,3 +8,4 @@ xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 
 xdebug.log=/tmp/xdebug.log
+xdebug.discover_client_host=true

--- a/php-fpm/rootfs82/etc/php82/conf.d/xdebug.ini.template
+++ b/php-fpm/rootfs82/etc/php82/conf.d/xdebug.ini.template
@@ -8,3 +8,4 @@ xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 
 xdebug.log=/tmp/xdebug.log
+xdebug.discover_client_host=true


### PR DESCRIPTION
# Description
To cover more scenarios and support xdebug with zero config we are adding discover_client_host.

That way xdebug will also atempt to connect to the caller as well as backup to client_host (`host.docker.internal`)

# Test

Change your dev-env .lando.yml to something like:

```
  php:
    type: compose
    services:
      # image: ghcr.io/automattic/vip-container-images/php-fpm:8.0
      build:
        context: /home/pavel/git/automattic/vip-container-images/php-fpm
        dockerfile: /home/pavel/git/automattic/vip-container-images/php-fpm/Dockerfile.80
```