### PR TITLE
feat(wordpress): Add entrypoint script

### DIFF
--- a/wordpress/.dockerignore
+++ b/wordpress/.dockerignore
@@ -1,2 +1,3 @@
 *
+!entrypoint.sh
 !extra

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -19,3 +19,5 @@ COPY extra/ /wordpress/wordpress/
 
 FROM ghcr.io/automattic/vip-container-images/alpine:3.17.3@sha256:062a1ec3e5d1d7c471add8bb689ccd26a3d6a734c802bbbc37d8f456ddb27b40
 COPY --from=build /wordpress/wordpress/ /wp/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/wordpress/entrypoint.sh
+++ b/wordpress/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+: "${LANDO_WEBROOT_USER:=www-data}"
+: "${LANDO_WEBROOT_GROUP:=www-data}"
+
+if [ -n "${LANDO_HOST_UID}" ] && [ -n "${LANDO_HOST_GID}" ]; then
+    usermod -u "${LANDO_HOST_UID}" "${LANDO_WEBROOT_USER}"
+    groupmod -g "${LANDO_HOST_GID}" "${LANDO_WEBROOT_GROUP}"
+fi
+
+rsync -a --chown="${LANDO_WEBROOT_USER}:${LANDO_WEBROOT_GROUP}" /wp/ /shared/


### PR DESCRIPTION
This PR is required for https://github.com/Automattic/vip-cli/pull/1341 so that we can make `wordpress` an init-only container.
