### PR TITLE
feat(php-fpm): Add support for running cron

### DIFF
--- a/php-fpm-ubuntu/rootfs/etc/default/locale
+++ b/php-fpm-ubuntu/rootfs/etc/default/locale
@@ -1,1 +1,0 @@
-LANG="en_US.UTF-8"

--- a/php-fpm-ubuntu/rootfs/etc/default/locale
+++ b/php-fpm-ubuntu/rootfs/etc/default/locale
@@ -1,0 +1,1 @@
+LANG="en_US.UTF-8"

--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -30,7 +30,8 @@ RUN \
     eatmydata apt-get remove --purge -y software-properties-common && \
     rm -rf /var/lib/apt/lists/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm7.4 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm7.4 /usr/sbin/php-fpm && \
+    chmod 02755 /usr/bin/crontab
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -19,7 +19,7 @@ RUN \
     apt-get -y install eatmydata && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
-    eatmydata apt-get install -y curl less git jq mysql-client openssl wget && \
+    eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y \
         php7.4-cli php7.4-fpm \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -30,7 +30,8 @@ RUN \
     eatmydata apt-get remove --purge -y software-properties-common && \
     rm -rf /var/lib/apt/lists/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.0 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.0 /usr/sbin/php-fpm && \
+    chmod 02755 /usr/bin/crontab
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -19,7 +19,7 @@ RUN \
     apt-get -y install eatmydata && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
-    eatmydata apt-get install -y curl less git jq mysql-client openssl wget && \
+    eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y \
         php8.0-cli php8.0-fpm \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -19,7 +19,7 @@ RUN \
     apt-get -y install eatmydata && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
-    eatmydata apt-get install -y curl less git jq mysql-client openssl wget && \
+    eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y \
         php8.1-cli php8.1-fpm \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -30,7 +30,8 @@ RUN \
     eatmydata apt-get remove --purge -y software-properties-common && \
     rm -rf /var/lib/apt/lists/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm && \
+    chmod 02755 /usr/bin/crontab
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -30,7 +30,8 @@ RUN \
     eatmydata apt-get remove --purge -y software-properties-common && \
     rm -rf /var/lib/apt/lists/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
+    chmod 02755 /usr/bin/crontab
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -19,7 +19,7 @@ RUN \
     apt-get -y install eatmydata && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
-    eatmydata apt-get install -y curl less git jq mysql-client openssl wget && \
+    eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y \
         php8.2-cli php8.2-fpm \

--- a/php-fpm/rootfs/etc/default/locale
+++ b/php-fpm/rootfs/etc/default/locale
@@ -1,0 +1,1 @@
+LANG="en_US.UTF-8"

--- a/php-fpm/rootfs/usr/local/bin/run.sh
+++ b/php-fpm/rootfs/usr/local/bin/run.sh
@@ -17,4 +17,17 @@ else
     phpdismod mailhog mailpit
 fi
 
-exec /usr/sbin/php-fpm
+cleanup() {
+    if [ -n "${ENABLE_CRON}" ]; then
+        /usr/sbin/service cron stop
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+if [ -n "${ENABLE_CRON}" ]; then
+    echo "*/10 * * * * /usr/local/bin/wp core is-installed && /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp cron event run --due-now" | crontab -u www-data -
+    /usr/sbin/service cron start
+fi
+
+/usr/sbin/php-fpm

--- a/php-fpm/rootfs/usr/local/bin/run.sh
+++ b/php-fpm/rootfs/usr/local/bin/run.sh
@@ -26,7 +26,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if [ -n "${ENABLE_CRON}" ]; then
-    echo "*/10 * * * * /usr/local/bin/wp core is-installed && /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp cron event run --due-now" | crontab -u www-data -
+    echo "*/10 * * * * /usr/local/bin/wp --path=/wp core is-installed && /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp --path=/wp cron event run --due-now" | crontab -u www-data -
     /usr/sbin/service cron start
 fi
 

--- a/php-fpm/rootfs/usr/local/bin/run.sh
+++ b/php-fpm/rootfs/usr/local/bin/run.sh
@@ -26,7 +26,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if [ -n "${ENABLE_CRON}" ]; then
-    echo "*/10 * * * * /usr/local/bin/wp --path=/wp core is-installed && /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp --path=/wp cron event run --due-now" | crontab -u www-data -
+    echo "*/10 * * * * /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp-cron.sh" | crontab -u www-data -
     /usr/sbin/service cron start
 fi
 

--- a/php-fpm/rootfs/usr/local/bin/wp-cron.sh
+++ b/php-fpm/rootfs/usr/local/bin/wp-cron.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+export WP_CLI_CONFIG_PATH=/config/wp-cli.yaml
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+
+if ! wp core is-installed; then
+    exit 0;
+fi
+
+if wp core is-installed --network; then
+    urls="$(wp site list --field=url)"
+    for url in $urls; do
+        wp --url="${url}" cron event run --due-now
+    done
+else
+    wp cron event run --due-now
+fi
+
+exit 0

--- a/php-fpm/rootfs/usr/local/bin/wp-cron.sh
+++ b/php-fpm/rootfs/usr/local/bin/wp-cron.sh
@@ -9,7 +9,7 @@ fi
 
 if wp core is-installed --network; then
     urls="$(wp site list --field=url)"
-    for url in $urls; do
+    for url in ${urls}; do
         wp --url="${url}" cron event run --due-now
     done
 else


### PR DESCRIPTION
Steps to test:

1. `vip dev-env create < /dev/null`
2. `vip dev-env update -P image:ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0`
3. `vip dev-env start`
4. Build PHP 8 locally: `docker build -t ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0 -f Dockerfile.80 .`
5. Add `ENABLE_CRON: 1` after `XDEBUG: disable` to `.lando.yml`
6. `vip dev-env start`
7. `crontab -l` should show `*/10 * * * * /usr/local/bin/wp core is-installed && /usr/bin/flock -n /tmp/wp-cron.lock /usr/local/bin/wp cron event run --due-now`
8. `ps faux | grep cron` should show `cron` is running
9. Run `wp cron event list`, then meditate for 10 minutes, run `wp cron event list` again. `next_run_gmt` should change for `a8c_cron_control_force_publish_missed_schedules` and `vip_config_sync_cron`.

