### PR TITLE
Include php errors to stderr

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -129,4 +129,7 @@ function dev_env_auto_login() {
 	exit;
 }
 
-ini_set( 'error_log', '/dev/stderr' );
+// Force log to `/dev/stderr` so we get the errors in docker logs
+if ( 'Linux' === PHP_OS ) {
+	ini_set( 'error_log', '/dev/stderr' );
+}

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -130,6 +130,6 @@ function dev_env_auto_login() {
 }
 
 // Force log to `/dev/stderr` so we get the errors in docker logs
-if ( 'Linux' === PHP_OS ) {
+if ( 'Windows' !== PHP_OS_FAMILY ) {
 	ini_set( 'error_log', '/dev/stderr' );
 }

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -128,3 +128,5 @@ function dev_env_auto_login() {
 	wp_safe_redirect( admin_url() );
 	exit;
 }
+
+ini_set( 'error_log', '/dev/stderr' );

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -149,6 +149,6 @@ if ( ! defined( 'JETPACK_STAGING_MODE' ) ) {
 }
 
 // Force log to `/dev/stderr` so we get the errors in docker logs
-if ( 'Linux' === PHP_OS ) {
+if ( 'Windows' !== PHP_OS_FAMILY ) {
 	ini_set( 'error_log', '/dev/stderr' );
 }

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -147,3 +147,8 @@ if ( ! defined( 'FORCE_SSL_ADMIN' ) ) {
 if ( ! defined( 'JETPACK_STAGING_MODE' ) ) {
 	define( 'JETPACK_STAGING_MODE', true );
 }
+
+// Force log to `/dev/stderr` so we get the errors in docker logs
+if ( 'Linux' === PHP_OS ) {
+	ini_set( 'error_log', '/dev/stderr' );
+}


### PR DESCRIPTION
This change prints php errors to stderr. This in turn makes it readable from `docker logs` which is what is used under the hood of `vip dev-env logs`.

We moved the setting to both mu-plugin and wp-config so that we catch logs both before and after mu-plugins. 

We also added OS check.
