### PR TITLE
Autologin: drop param if logged in already

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -103,7 +103,13 @@ function dev_env_auto_login() {
 	if ( 'local' !== VIP_GO_APP_ENVIRONMENT ) {
 		return;
 	}
+
+	$submitted_key = $_GET['vip-dev-autologin'] ?? false;
 	if ( is_user_logged_in() ) {
+		if ( $submitted_key ) {
+			wp_safe_redirect( admin_url() );
+			exit;
+		}
 		return;
 	}
 
@@ -111,7 +117,6 @@ function dev_env_auto_login() {
 	if ( ! $expected_key ) {
 		return;
 	}
-	$submitted_key = $_GET['vip-dev-autologin'] ?? false;
 	if ( $submitted_key !== $expected_key ) {
 		return;
 	}


### PR DESCRIPTION
If user is already logged in the wp-admin stays with : `?vip-dev-autologin=f474326f-ec59-46b9-b272-6c4f836e9c59`

This change adds one more redirect in that case in order to shave off the param