### PR TITLE
fix(dev-tools): `mountpoint` behaves differently in Alpine and Ubuntu

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -72,7 +72,7 @@ do
   fi
 done
 
-if mountpoint -q /wp/wp-content/mu-plugins; then
+if [ -n "${LANDO_INFO}" ] && [ "$(echo "${LANDO_INFO}" | jq -r '.["vip-mu-plugins"]')" != 'null' ]; then
   echo 'Waiting for mu-plugins...'
   i=0;
   while [ ! -f /wp/wp-content/mu-plugins/.version ]; do
@@ -144,7 +144,7 @@ fi
 echo "Checking for WordPress installation..."
 
 wp cache flush
-if ! wp core is-installed; then
+if ! wp core is-installed --skip-plugins --skip-themes; then
   echo "No installation found, installing WordPress..."
 
   # Ensuring wp-config-defaults is up to date


### PR DESCRIPTION
In Ubuntu, `mountpoint` parses `/proc/self/mountinfo`.
In Alpine, it [checks the device and inode number](https://github.com/brgl/busybox/blob/master/miscutils/mountpoint.c#LL78C4-L78C68) for `dir` and `dir/..`.

As a result:
* in Ubuntu, both bind mount and volume mounts are detected as mount points;
* in Alpine, only volume mounts are detected as mount points.

This causes issues when we bind `mu-plugins` from the host into a container.

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/5176836000/jobs/9326300205?pr=4540#step:12:1087
