### PR TITLE
fix(php-fpm): Remove erroneous `cp` command

### DIFF
--- a/php-fpm/rootfs/usr/local/bin/run.sh
+++ b/php-fpm/rootfs/usr/local/bin/run.sh
@@ -3,7 +3,6 @@
 if [ "enable" = "$XDEBUG" ]; then
     echo "Enabling XDebug"
     phpenmod -s fpm xdebug
-    cp "$XDEBUG_CONFIG_TEMPLATE_LOCATION" "$XDEBUG_CONFIG_TARGET_LOCATION"
 else
     echo "Disabling XDebug"
     phpdismod -s fpm xdebug


### PR DESCRIPTION
This fixes

```
php_1             | 2023-06-20T05:55:52.041279178Z cp: cannot stat '': No such file or directory
```

when XDebug is enabled.
