### PR TITLE
Load from vip-config too

### DIFF
--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -118,6 +118,9 @@ define( 'FILES_CLIENT_SITE_ID', 200508 );
 if ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {
 	require_once( ABSPATH . '/wp-content/vip-config/vip-config.php' );
 }
+if ( file_exists( ABSPATH . '/vip-config/vip-config.php' ) ) {
+	require_once( ABSPATH . '/vip-config/vip-config.php' );
+}
 
 /**
  * Enterprise Search

--- a/dev-tools/wp-config-defaults.php
+++ b/dev-tools/wp-config-defaults.php
@@ -117,8 +117,7 @@ define( 'FILES_CLIENT_SITE_ID', 200508 );
  */
 if ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {
 	require_once( ABSPATH . '/wp-content/vip-config/vip-config.php' );
-}
-if ( file_exists( ABSPATH . '/vip-config/vip-config.php' ) ) {
+} elseif ( file_exists( ABSPATH . '/vip-config/vip-config.php' ) ) {
 	require_once( ABSPATH . '/vip-config/vip-config.php' );
 }
 


### PR DESCRIPTION
We load vip-config.php currently from `/wp/wp-content/vip-config/vip-config.php` however in live environments the vip-config folders is mapped directly to `/wp/vip-config`  (not under `wp-content`).

We should migrate the location to more closely match the prod environment. That way we can support other files too such as `client-sunrise.php` which [is loaded ](https://github.com/Automattic/vip-go-mu-plugins/blob/7294c3902d473c57c58e8505d4ad396de3470d0b/lib/sunrise/sunrise.php#L100-L106)from  `/wp/vip-config/client-sunrise.php`

This is first part of the change where we load from both places. After that we cna change the mapping to the new place