### PR TITLE
Fix " Undefined constant "VIP_GO_APP_ENVIRONMENT"

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -100,7 +100,7 @@ function dev_env_add_admin( $args, $assoc_args ) {
 
 add_action( 'init', 'dev_env_auto_login' );
 function dev_env_auto_login() {
-	if ( 'local' !== VIP_GO_APP_ENVIRONMENT ) {
+	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' !== VIP_GO_APP_ENVIRONMENT ) {
 		return;
 	}
 

--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -100,7 +100,7 @@ function dev_env_add_admin( $args, $assoc_args ) {
 
 add_action( 'init', 'dev_env_auto_login' );
 function dev_env_auto_login() {
-	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' !== VIP_GO_APP_ENVIRONMENT ) {
+	if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' !== VIP_GO_APP_ENVIRONMENT ) {
 		return;
 	}
 


### PR DESCRIPTION
Running into `Undefined constant "VIP_GO_APP_ENVIRONMENT" in /var/www/html/wp-content/mu-plugins/dev-env-plugin.php:103` as I try to do `npm run search-env:start` for tests.