### PR TITLE
ci: allow for building images from Dockerfile directory

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v5
         with:
-          file: alpine/Dockerfile
+          context: alpine
           platforms: linux/amd64,linux/arm64
           push: ${{ github.base_ref == null }}
           cache-from: type=gha,scope=alpine

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -47,7 +47,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: dev-tools
-          file: dev-tools/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.base_ref == null }}
           cache-from: type=gha,scope=dev-tools

--- a/.github/workflows/mu-plugins.yml
+++ b/.github/workflows/mu-plugins.yml
@@ -52,7 +52,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: mu-plugins
-          file: mu-plugins/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.base_ref == null }}
           tags: |

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v5
         with:
-          file: nginx/Dockerfile
+          context: nginx
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=nginx
           cache-to: type=gha,mode=max,scope=nginx

--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v5
         with:
-          file: skeleton/Dockerfile
+          context: skeleton
           platforms: linux/amd64,linux/arm64
           push: ${{ github.base_ref == null }}
           tags: |

--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v5
         with:
-          file: traefik/Dockerfile
+          context: traefik
           platforms: linux/amd64,linux/arm64
           push: ${{ github.base_ref == null }}
           cache-from: type=gha,scope=traefik

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,4 +2,4 @@ FROM nginx:1.25.3-alpine@sha256:db353d0f0c479c91bd15e01fc68ed0f33d9c4c52f3415e63
 
 RUN apk add --no-cache shadow
 
-COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This PR:
* allows for building Docker images from the directory where `Dockerfile` is located, not from the repo's root directory;
* reduces the amount of data sent to the Docker daemon to build the image.
