### PR TITLE
fix(php-fpm): clean cache after package installation

### DIFF
--- a/php-fpm/Dockerfile.74
+++ b/php-fpm/Dockerfile.74
@@ -7,7 +7,8 @@ RUN \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y php7.4-dev php7.4-xml && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
-    pecl install timezonedb
+    pecl install timezonedb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
 
@@ -28,7 +29,7 @@ RUN \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     eatmydata apt-get remove --purge -y software-properties-common && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm7.4 /usr/sbin/php-fpm && \
     chmod 02755 /usr/bin/crontab

--- a/php-fpm/Dockerfile.80
+++ b/php-fpm/Dockerfile.80
@@ -7,7 +7,8 @@ RUN \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y php8.0-dev php8.0-xml && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
-    pecl install timezonedb
+    pecl install timezonedb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
 
@@ -28,7 +29,7 @@ RUN \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     eatmydata apt-get remove --purge -y software-properties-common && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.0 /usr/sbin/php-fpm && \
     chmod 02755 /usr/bin/crontab

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -7,7 +7,8 @@ RUN \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y php8.1-dev php8.1-xml && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
-    pecl install timezonedb
+    pecl install timezonedb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
 
@@ -28,7 +29,7 @@ RUN \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     eatmydata apt-get remove --purge -y software-properties-common && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm && \
     chmod 02755 /usr/bin/crontab

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -7,7 +7,8 @@ RUN \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y php8.2-dev php8.2-xml && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
-    pecl install timezonedb
+    pecl install timezonedb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
 
@@ -28,7 +29,7 @@ RUN \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     eatmydata apt-get remove --purge -y software-properties-common && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
     chmod 02755 /usr/bin/crontab

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -6,7 +6,8 @@ RUN \
     eatmydata apt-get install -y software-properties-common gnupg libmcrypt-dev zlib1g-dev libmemcached-dev libgraphicsmagick1-dev --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y php8.3-dev php8.3-xml && \
-    eatmydata apt-get install -y php-pear --no-install-recommends
+    eatmydata apt-get install -y php-pear --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN \
     cp \
@@ -43,7 +44,7 @@ RUN \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     eatmydata apt-get remove --purge -y software-properties-common && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm && \
     chmod 02755 /usr/bin/crontab


### PR DESCRIPTION
This PR fixes the docker:S6587 issue: Cache should be cleaned after package installation

> Docker images should only contain necessary data. The package index is optional for the correct working of the installed software. Storing an index also increases the size of the Docker image. It should be reduced to speed up deployments and reduce storage and bandwidth.