### PR TITLE
security(alpine): fix CVE-2023-5363

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -13,6 +13,7 @@ on:
       - "alpine/**"
       - ".github/workflows/alpine.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -44,5 +45,6 @@ jobs:
           push: ${{ github.base_ref == null }}
           cache-from: type=gha,scope=alpine
           cache-to: type=gha,mode=max,scope=alpine
+          no-cache: ${{ github.event_name == 'workflow_dispatch' }}
           primaryTag: ghcr.io/automattic/vip-container-images/alpine:${{ steps.getversion.outputs.version }}
           tags: ghcr.io/automattic/vip-container-images/alpine:latest

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
+RUN apk upgrade --no-cache
+
 # Common packages needed for most images
 # - rsync: Needed to copy code to k8s/docker-compose volumes
 # - shadow: Needed to setup Lando dev environments


### PR DESCRIPTION
Fix CVE-2023-5363 (medium severity) affecting `libssl3` and `libcrypto3`.

Ref: https://github.com/Automattic/vip-container-images/pull/565#issuecomment-1784572462
Ref: https://avd.aquasec.com/nvd/cve-2023-5363
