### PR TITLE
ci: add workflow_dispatch to all build workflows

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -13,6 +13,7 @@ on:
       - "dev-tools/**"
       - ".github/workflows/dev-tools.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -13,6 +13,7 @@ on:
       - "nginx/**"
       - ".github/workflows/nginx.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/photon.yml
+++ b/.github/workflows/photon.yml
@@ -13,6 +13,7 @@ on:
       - "photon/**"
       - ".github/workflows/photon.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -13,6 +13,7 @@ on:
       - "php-fpm/**"
       - ".github/workflows/php-fpm.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -13,6 +13,7 @@ on:
       - "traefik/**"
       - ".github/workflows/traefik.yml"
       - ".github/actions/build-docker-image/**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR adds a `workflow_dispatch` trigger to all our build workflows so that we can trigger them manually in case we need to rebuild an image.

Note: Alpine workflow is updated in #568 in order not to create merge conflicts.
