### PR TITLE
security(nginx): fix CVE-2023-43785, CVE-2023-43786, CVE-2023-43787

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:1.25.3-alpine@sha256:db353d0f0c479c91bd15e01fc68ed0f33d9c4c52f3415e63332c3d0bf7a4bb77
 
-RUN apk add --no-cache shadow
+RUN apk upgrade --no-cache && apk add --no-cache shadow
 
 COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- CVE-2023-43785 (medium severity): out-of-bounds memory access in _XkbReadKeySyms()
- CVE-2023-43786 (medium severity): stack exhaustion from infinite recursion in PutSubImage()
- CVE-2023-43787 (high severity): integer overflow in XCreateImage() leading to a heap overflow
