### PR TITLE
security: fix CVE-2023-5678

### DIFF
--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:6b50cbfe31bd2f0162c8b7924fd14bd58a7b2a07ca51d641d952deb7306762ac
+FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:e818ca66bea1d187f8b3bd471a55bab64a90ad72dc58edb3ae01bb2d54f39ce6
 
 COPY setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools/
 COPY scripts /scripts

--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:6b50cbfe31bd2f0162c8b7924fd14bd58a7b2a07ca51d641d952deb7306762ac
+FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:e818ca66bea1d187f8b3bd471a55bab64a90ad72dc58edb3ae01bb2d54f39ce6
 
 RUN \
     apk add --no-cache git && \

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:6b50cbfe31bd2f0162c8b7924fd14bd58a7b2a07ca51d641d952deb7306762ac
+FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:e818ca66bea1d187f8b3bd471a55bab64a90ad72dc58edb3ae01bb2d54f39ce6
 
 RUN apk add --no-cache --virtual build-deps git && \
     git clone --depth=1 https://github.com/Automattic/vip-go-skeleton/ /clientcode && \

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:6b50cbfe31bd2f0162c8b7924fd14bd58a7b2a07ca51d641d952deb7306762ac AS build
+FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:e818ca66bea1d187f8b3bd471a55bab64a90ad72dc58edb3ae01bb2d54f39ce6 AS build
 ARG WP_GIT_REF
 RUN apk add --no-cache git git-subtree patch
 RUN mkdir /wordpress
@@ -17,7 +17,7 @@ RUN \
 
 COPY extra/ /wordpress/wordpress/
 
-FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:6b50cbfe31bd2f0162c8b7924fd14bd58a7b2a07ca51d641d952deb7306762ac
+FROM ghcr.io/automattic/vip-container-images/alpine:3.18.4@sha256:e818ca66bea1d187f8b3bd471a55bab64a90ad72dc58edb3ae01bb2d54f39ce6
 COPY --from=build /wordpress/wordpress/ /wp/
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Affects:
* dev-tools
* mu-plugins
* skeleton
* wordpress