### PR TITLE
mu-plugins: .dockerignore was not taking any effect, switching to rsync approach we do for mu-plugins-ext, also uninstall git

### DIFF
--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -2,15 +2,18 @@ FROM ghcr.io/automattic/vip-container-images/alpine:3.18.5@sha256:2f570165292f81
 
 RUN \
     apk add --no-cache git && \
-    git clone --depth 1 --no-remote-submodules -b staging https://github.com/Automattic/vip-go-mu-plugins /mu-plugins && \
+    mkdir -p /mu-plugins && \
+    git clone --depth 1 --no-remote-submodules -b staging https://github.com/Automattic/vip-go-mu-plugins /mu-plugins-tmp && \
+    # cp /mu-plugins/.dockerignore /.dockerignore && \
     git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext && \
-    cd /mu-plugins && \
+    cd /mu-plugins-tmp && \
     sed -i -e "s,git@github.com:,https://github.com/," .gitmodules && \
     git submodule update --init --recursive --depth 1 && \
-    rsync -a -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /mu-plugins && \
-    rm -rf /mu-plugins-ext && \
-    rm -rf /mu-plugins/tests /mu-plugins/__tests__ /mu-plugins/bin /mu-plugins/ci && \
     gitsha=$(git rev-parse --short HEAD) && gitdate=$(git show -s --format=%cs "$gitsha") && date=$(date -d "$gitdate" '+%Y%m%d') && echo "{ \"tag\": \"staging\", \"stack_version\": \"${date}-${gitsha}\" }" > "/mu-plugins/.version" && \
+    rsync -a -r --delete --exclude-from="/mu-plugins-tmp/.dockerignore" /mu-plugins-tmp/* /mu-plugins && \
+    rsync -a -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /mu-plugins && \
+    rm -rf /mu-plugins-tmp /mu-plugins-ext && \
+    apk del git && \
     install -d -m 0755 /shared
 
 COPY run.sh /run.sh


### PR DESCRIPTION

This shaves off about 100mb from the image.