### PR TITLE
Add .devenvignore support for ext repo

### DIFF
--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /mu-plugins-tmp
 RUN sed -i -e "s,git@github.com:,https://github.com/," .gitmodules && git submodule update --init --recursive --depth 1 --single-branch --jobs 8
 RUN gitsha=$(git rev-parse --short HEAD) && gitdate=$(git show -s --format=%cs "$gitsha") && date=$(date -d "$gitdate" '+%Y%m%d') && echo "{ \"tag\": \"staging\", \"stack_version\": \"${date}-${gitsha}\" }" > "/mu-plugins/.version"
 RUN rsync -a -r --delete --exclude-from="/mu-plugins-tmp/.dockerignore" /mu-plugins-tmp/* /mu-plugins
-RUN rsync -a -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" /mu-plugins-ext/* /mu-plugins
+RUN rsync -a -r --delete --exclude-from="/mu-plugins-ext/.dockerignore" --exclude-from="/mu-plugins-ext/.devenvignore" /mu-plugins-ext/* /mu-plugins
 
 
 FROM ghcr.io/automattic/vip-container-images/alpine:3.19.0@sha256:43e68e32a67c813ffa4ee5a9355a353d42a24e307474978b765b91ab942b4758


### PR DESCRIPTION
To prevent bloat from integrations making it to the dev env we've introduced a new .devenvignore file where we can block particular versions from the build process.