### PR TITLE
fix(dev-tools): grant privileges to MySQL users properly

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -112,28 +112,14 @@ if ! mysqladmin ping -h "${db_host}" --silent; then
     exit 1;
 fi
 
-echo "Checking for database connectivity..."
-if ! mysql -h "$db_host" -u wordpress -pwordpress wordpress -e "SELECT 'testing_db'" >/dev/null 2>&1; then
-  echo "No WordPress database exists, provisioning..."
-  {
-    echo "CREATE USER IF NOT EXISTS 'wordpress'@'localhost' IDENTIFIED BY 'wordpress';"
-    echo "CREATE USER IF NOT EXISTS 'wordpress'@'%' IDENTIFIED BY 'wordpress';"
-    echo "GRANT ALL ON *.* TO 'wordpress'@'localhost';"
-    echo "GRANT ALL ON *.* TO 'wordpress'@'%';"
-    echo "GRANT SET_ANY_DEFINER ON *.* TO 'wordpress'@'localhost';"
-    echo "GRANT SET_ANY_DEFINER ON *.* TO 'wordpress'@'%';"
-    echo "CREATE DATABASE IF NOT EXISTS wordpress;"
-  } | mysql -h "$db_host" -u "$db_admin_user"
-fi
-
-if ! mysql -h "${db_host}" -unetapp -pwordpress wordpress -e "SELECT 'testing_db'" >/dev/null 2>&1; then
-  {
-    echo "CREATE USER IF NOT EXISTS 'netapp'@'localhost' IDENTIFIED BY 'wordpress';"
-    echo "CREATE USER IF NOT EXISTS 'netapp'@'%' IDENTIFIED BY 'wordpress';"
-    echo "GRANT ALL ON *.* TO 'netapp'@'localhost';"
-    echo "GRANT ALL ON *.* TO 'netapp'@'%';"
-  } | mysql -h "${db_host}" -u "${db_admin_user}"
-fi
+{
+  echo "CREATE USER IF NOT EXISTS 'wordpress'@'%' IDENTIFIED BY 'wordpress';"
+  echo "CREATE USER IF NOT EXISTS 'netapp'@'%' IDENTIFIED BY 'wordpress';"
+  echo "GRANT ALL ON wordpress.* TO 'wordpress'@'%';"
+  echo "GRANT ALL ON wordpress.* TO 'netapp'@'%';"
+  echo "GRANT SET_ANY_DEFINER ON *.* TO 'wordpress'@'%';"
+  echo "CREATE DATABASE IF NOT EXISTS wordpress;"
+} | mysql -h "$db_host" -u "$db_admin_user"
 
 echo "Copying dev-env-plugin.php to mu-plugins"
 cp /dev-tools/dev-env-plugin.php /wp/wp-content/mu-plugins/


### PR DESCRIPTION
The issue was that `docker-compose.yml` instructed MySQL to create the user: https://github.com/Automattic/vip-cli/blob/trunk/assets/dev-env.lando.template.yml.ejs#L99-L101

As a consequence, `if ! mysql -h "$db_host" -u wordpress -pwordpress wordpress -e "SELECT 'testing_db'" >/dev/null 2>&1; then` was always false, and we did not grant the user the `SET_ANY_DEFINER` privilege.

Moreover, the `GRANT ALL ON *.* TO 'netapp'@'%';` caused issues later because MySQL grants all privileges to the user [only on the specific database](https://hub.docker.com/_/mysql). We grant `netapp` all privileges on all databases, and MySQL was unhappy about it on import: "Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation".

What has changed now:
* We do not try to create `...`@`localhost` users anymore: MySQL did not do that, and we probably should not either;
* We grant all privileges to users only on the `wordpress` database; this corresponds to what MySQL does;
* We do not check anymore if the user exists. It does (except for very outdated versions of vip-cli), but it does not have the `SET_ANY_DEFINER` privilege by default. `IF NOT EXISTS` clauses guard against errors if the user or the database already exists. Duplicate `GRANT` statements are harmless.
