### PR TITLE
Update to WP 6.5 RC1

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -42,7 +42,7 @@
     "prerelease": true
   },
   {
-    "ref": "53b99200d6000ff43effb3fd615cbe6a65d6b5e4",
+    "ref": "da015a655cf5fb811ef1e444eed9710d97042542",
     "tag": "6.5",
     "cacheable": false,
     "locked": false,


### PR DESCRIPTION
Pointed at the "branch 6.5" commit in this branch: https://github.com/WordPress/WordPress/commits/6.5-branch