### PR TITLE
Bump up fastcgi_buffer_size to 64k to pad prod value a bit

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,4 +1,9 @@
 fastcgi_cache_path /var/cache/nginx/photon levels=2 keys_zone=photon:20m max_size=100m inactive=20m;
+client_body_buffer_size 256k;
+
+# These are intentionally slightly larger than production values
+fastcgi_buffers 256 4k;
+fastcgi_buffer_size 64k;
 
 server {
 
@@ -86,8 +91,6 @@ server {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 
     fastcgi_intercept_errors on;
-    fastcgi_buffers 256 4k;
-    fastcgi_buffer_size 48k;
   }
 
   location @index.php {


### PR DESCRIPTION
Sometimes customers get 502 errors which are tricky to debug, this should give a bit of a breathing room.

Probably worth doing a custom 502 error page to describe potential solutions for 502 errors. 