### PR TITLE
ci: attest build provenance for Docker images

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -64,6 +64,7 @@ runs:
 
     - name: Build and push container image
       uses: docker/build-push-action@v5
+      id: push
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
@@ -76,6 +77,19 @@ runs:
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         no-cache: ${{ inputs.no-cache }}
+
+    - name: Get image name
+      shell: bash
+      id: imagename
+      run: echo "image_name=$(echo "${{ inputs.primaryTag }}" | cut -d ':' -f 1)" >> "${GITHUB_OUTPUT}"
+
+    - name: Attest
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-name: ${{ steps.imagename.outputs.image_name }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: false
+      if: inputs.push == 'true'
 
     - name: Load image to local Docker
       uses: docker/build-push-action@v5

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-skeleton.yml
+++ b/.github/workflows/build-skeleton.yml
@@ -17,6 +17,8 @@ jobs:
       packages: write
       contents: read
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/mu-plugins.yml
+++ b/.github/workflows/mu-plugins.yml
@@ -34,6 +34,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/photon.yml
+++ b/.github/workflows/photon.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/skeleton.yml
+++ b/.github/workflows/skeleton.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -31,6 +31,8 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -48,6 +48,8 @@ jobs:
       packages: write
       pull-requests: write
       security-events: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Artifact attestations enable us to create unfalsifiable provenance and integrity guarantees for the images we build, thus increasing their supply chain security. People who consume our images can verify where and how they were built.
