### PR TITLE
ci: publish attestations to the container registry

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -88,7 +88,7 @@ runs:
       with:
         subject-name: ${{ steps.imagename.outputs.image_name }}
         subject-digest: ${{ steps.push.outputs.digest }}
-        push-to-registry: false
+        push-to-registry: true
       if: inputs.push == 'true'
 
     - name: Load image to local Docker


### PR DESCRIPTION
Now that the provenance attestations are [successfully generated and pass validation](https://github.com/Automattic/vip-container-images/attestations), it is time to push them into the container registry.
