### PR TITLE
fix(php-fpm): honor `LD_LIBRARY_PATH` `eatmydata` expects

### DIFF
--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -17,7 +17,9 @@ FROM ubuntu:22.04
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get -q update && \
-    apt-get -y install eatmydata && eatmydata apt-get -y upgrade && \
+    apt-get -y install eatmydata && \
+    mkdir -p /usr/lib/libeatmydata && ln -s -t /usr/lib/libeatmydata/ /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so* && \
+    eatmydata apt-get -y upgrade && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron vim nano && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -17,7 +17,9 @@ FROM ubuntu:22.04
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get -q update && \
-    apt-get -y install eatmydata && eatmydata apt-get -y upgrade && \
+    apt-get -y install eatmydata && \
+    mkdir -p /usr/lib/libeatmydata && ln -s -t /usr/lib/libeatmydata/ /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so* && \
+    eatmydata apt-get -y upgrade && \
     eatmydata apt-get install -y software-properties-common gnupg --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron vim nano && \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -16,7 +16,9 @@ FROM ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get -q update && \
-    apt-get -y install eatmydata && eatmydata apt-get -y upgrade && \
+    apt-get -y install eatmydata && \
+    mkdir -p /usr/lib/libeatmydata && ln -s -t /usr/lib/libeatmydata/ /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so* && \
+    eatmydata apt-get -y upgrade && \
     eatmydata apt-get install -y software-properties-common gnupg libmcrypt4 zlib1g libmemcached11 libgraphicsmagick-q16-3 --no-install-recommends && \
     eatmydata add-apt-repository -y ppa:ondrej/php && \
     eatmydata apt-get install -y curl less git jq mysql-client openssl wget cron vim nano && \


### PR DESCRIPTION
`eatmydata` in Ubuntu is a bit broken: it sets the `LD_LIBRARY_PATH` environment variable to `/usr/lib/libeatmydata`:

```sh
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH:"}/usr/lib/libeatmydata
   LD_PRELOAD=${LD_PRELOAD:+"$LD_PRELOAD "}libeatmydata.so
   export LD_LIBRARY_PATH LD_PRELOAD
```

However, `libeatmydata.so` is located in a platform-dependent location, `/usr/lib/$(uname -m)-linux-gnu`.

This PR creates the `/usr/lib/libeatmydata` directory and symlinks all files matching `/usr/lib/$(uname -m)-linux-gnu/libeatmydata.so*` into it.
