### PR TITLE
fix(wp-test-runner): correct library path in `LD_PRELOAD`

### DIFF
--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -4,17 +4,19 @@ USER root
 RUN \
 	export DEBIAN_FRONTEND=noninteractive; \
 	echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
-	apt-get -qq update && apt-get -qq install eatmydata && \
+	apt-get -q update && \
+	apt-get -y install eatmydata && \
+	mkdir -p /usr/lib/libeatmydata && ln -s -t /usr/lib/libeatmydata/ /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so* && \
 	add-apt-repository -y ppa:ondrej/php && \
-	eatmydata apt-get -qq upgrade && \
-	eatmydata apt-get -qq install php8.0 php8.0-apcu php8.0-curl php8.0-gd php8.0-gmp php8.0-igbinary php8.0-imagick php8.0-imap php8.0-intl php8.0-mbstring php8.0-mysql php8.0-sqlite3 php8.0-xdebug php8.0-xml php8.0-xsl php8.0-zip php8.0-memcache php8.0-memcached && \
-	eatmydata apt-get -qq install php8.1 php8.1-apcu php8.1-curl php8.1-gd php8.1-gmp php8.1-igbinary php8.1-imagick php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xdebug php8.1-xml            php8.1-zip php8.1-memcache php8.1-memcached && \
-	eatmydata apt-get -qq install php8.2 php8.2-apcu php8.2-curl php8.2-gd php8.2-gmp php8.2-igbinary php8.2-imagick php8.2-imap php8.2-intl php8.2-mbstring php8.2-mysql php8.2-sqlite3 php8.2-xdebug php8.2-xml            php8.2-zip php8.2-memcache php8.2-memcached && \
-	eatmydata apt-get -qq install php8.3 php8.3-apcu php8.3-curl php8.3-gd php8.3-gmp php8.3-igbinary php8.3-imagick php8.3-imap php8.3-intl php8.3-mbstring php8.3-mysql php8.3-sqlite3 php8.3-xdebug php8.3-xml            php8.3-zip php8.3-memcache php8.3-memcached && \
-	eatmydata apt-get -qq install subversion unzip default-mysql-client && \
+	eatmydata apt-get -y upgrade && \
+	eatmydata apt-get -y install php8.0 php8.0-apcu php8.0-curl php8.0-gd php8.0-gmp php8.0-igbinary php8.0-imagick php8.0-imap php8.0-intl php8.0-mbstring php8.0-mysql php8.0-sqlite3 php8.0-xdebug php8.0-xml php8.0-xsl php8.0-zip php8.0-memcache php8.0-memcached && \
+	eatmydata apt-get -y install php8.1 php8.1-apcu php8.1-curl php8.1-gd php8.1-gmp php8.1-igbinary php8.1-imagick php8.1-imap php8.1-intl php8.1-mbstring php8.1-mysql php8.1-sqlite3 php8.1-xdebug php8.1-xml            php8.1-zip php8.1-memcache php8.1-memcached && \
+	eatmydata apt-get -y install php8.2 php8.2-apcu php8.2-curl php8.2-gd php8.2-gmp php8.2-igbinary php8.2-imagick php8.2-imap php8.2-intl php8.2-mbstring php8.2-mysql php8.2-sqlite3 php8.2-xdebug php8.2-xml            php8.2-zip php8.2-memcache php8.2-memcached && \
+	eatmydata apt-get -y install php8.3 php8.3-apcu php8.3-curl php8.3-gd php8.3-gmp php8.3-igbinary php8.3-imagick php8.3-imap php8.3-intl php8.3-mbstring php8.3-mysql php8.3-sqlite3 php8.3-xdebug php8.3-xml            php8.3-zip php8.3-memcache php8.3-memcached && \
+	eatmydata apt-get -y install subversion unzip default-mysql-client && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	echo "xdebug.mode=coverage" | tee -a /etc/php/*/mods-available/xdebug.ini && \
-	update-alternatives --set php /usr/bin/php8.0
+	update-alternatives --set php /usr/bin/php8.2
 
 RUN install -d -o circleci -g circleci -m 0777 /wordpress
 RUN wget -q https://getcomposer.org/installer -O - | php -- --install-dir=/usr/bin/ --filename=composer
@@ -28,7 +30,7 @@ RUN \
 
 USER circleci
 
-ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libeatmydata.so
+ENV LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so
 
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ENV NVM_DIR /home/circleci/.nvm


### PR DESCRIPTION
`eatmydata` in Ubuntu is a bit broken: it sets the `LD_LIBRARY_PATH` environment variable to `/usr/lib/libeatmydata`:

```sh
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH:"}/usr/lib/libeatmydata
   LD_PRELOAD=${LD_PRELOAD:+"$LD_PRELOAD "}libeatmydata.so
   export LD_LIBRARY_PATH LD_PRELOAD
```

However, `libeatmydata.so` is located in a platform-dependent location, `/usr/lib/$(uname -m)-linux-gnu`.

This PR creates the `/usr/lib/libeatmydata` directory and symlinks all files matching `/usr/lib/$(uname -m)-linux-gnu/libeatmydata.so*` into it.

Furthermore, this allows us not to use the platform-specific `LD_PRELOAD‌` path and refer to `/usr/lib/libeatmydata/libeatmydata.so` instead.
