### PR TITLE
Remove 500 from http status that gets intercepted by a custom error page

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,7 +2,7 @@ fastcgi_cache_path /var/cache/nginx/photon levels=2 keys_zone=photon:20m max_siz
 client_body_buffer_size 256k;
 fastcgi_buffers 256 4k;
 fastcgi_buffer_size 48k;
-error_page 500 502 503 504 /50x.html;
+error_page 502 503 504 /50x.html;
 
 server {
 


### PR DESCRIPTION
Some prefer debugging PHP runtime errors in browser so the previous change in #682 negatively affected that workflow.

