### PR TITLE
fix(php-fpm): startup issues for php-fpm 8.3

### DIFF
--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -36,9 +36,9 @@ RUN \
     ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm
 
 RUN \
+    deluser --remove-home --quiet ubuntu && \
     usermod -d /home/www-data -s /bin/bash www-data && \
     install -d -D -m 0750 -o www-data -g www-data /home/www-data && \
-    install -d -D -m 0777 -o www-data -g www-data /var/www/html && \
     install -d -D -m 0755 -o www-data -g www-data /run/php && \
     install -d -D -m 0755 -o root -g root /usr/local/share
 


### PR DESCRIPTION
```
loadkeys 07:09:38.89 INFO  ==> Scanning /lando/keys for keys...
loadkeys 07:09:38.89 INFO  ==> Scanning /var/www/.ssh for keys...
loadkeys 07:09:38.89 INFO  ==> Scanning /user/.ssh for keys...
loadkeys 07:09:38.90 INFO  ==> Found keys 
loadkeys 07:09:38.90 INFO  ==> Using the following keys: 
vip 07:09:38.90 INFO  ==> Making sure www-data id ('33') is correctly mapped to '1000'
vip 07:09:38.90 WARN  ==> User www-data is NOT correctly mapped. Will attempt to fix that.
vip 07:09:39.17 INFO  ==> Making sure group www-data exists
vip 07:09:39.17 WARN  ==> Group www-data doesn't exist. Will attempt to create it.
vip 07:09:39.22 INFO  ==> SUCCESS: group added
useradd: UID 1000 is not unique
vip 07:09:39.29 ERROR ==> User was not added
lando 07:09:39.29 INFO  ==> Lando handing off to: run.sh
lando 07:09:39.30 DEBUG ==> Running command with exec...
Disabling XDebug
[11-Jul-2024 07:09:39] ERROR: [pool www] cannot get uid for user 'www-data'
[11-Jul-2024 07:09:39] ERROR: FPM initialization failed
```