### PR TITLE
Allow setting WP_DEBUG, WP_DEBUG_LOG, and WP_DEBUG_DISPLAY in vip-config.php

### DIFF
--- a/dev-tools/wp-config.php.tpl
+++ b/dev-tools/wp-config.php.tpl
@@ -17,6 +17,8 @@ $memcached_servers = array (
   ),
 );
 
+require( __DIR__ . '/wp-config-defaults.php' );
+
 if ( ! defined( 'WP_DEBUG' ) ) {
     define( 'WP_DEBUG', true );
 }
@@ -28,5 +30,3 @@ if ( ! defined( 'WP_DEBUG_LOG' ) ) {
 if ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
 	define( 'WP_DEBUG_DISPLAY', false );
 }
-
-require( __DIR__ . '/wp-config-defaults.php' );


### PR DESCRIPTION
This change allows for `WP_DEBUG`, `WP_DEBUG_LOG`, and `WP_DEBUG_DISPLAY` to be set in `vip-config.php` by requiring `wp-config-defaults.php` before setting those constants in `wp-config.php.tpl`.