### PR TITLE
Add mydumper

### DIFF
--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -7,7 +7,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.1-dev php8.1-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
+    eatmydata apt-get install -y php8.1-dev php8.1-xml g++ cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,3 +1,5 @@
+FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
+
 FROM ubuntu:22.04 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -36,11 +38,7 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
-    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
-    dpkg -i mydumper.deb && \
-    rm mydumper.deb
+    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \
@@ -74,6 +72,8 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20210902/timezonedb.so /usr/lib/php/20210902/timezonedb.so
+COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
+COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.1/
 

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -36,7 +36,11 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
+    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    dpkg -i mydumper.deb && \
+    rm mydumper.deb
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -1,5 +1,3 @@
-FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
-
 FROM ubuntu:22.04 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -9,9 +7,16 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.1-dev php8.1-xml && \
+    eatmydata apt-get install -y php8.1-dev php8.1-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
+    curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
+    echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
+    tar -xzf mydumper.tar.gz && \
+    cd ./mydumper-0.16.3-6 && \
+    cmake . && \
+    make && \
+    make install && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
@@ -28,7 +33,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client libmysqlclient21 openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.1-cli php8.1-fpm \
@@ -72,8 +77,7 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20210902/timezonedb.so /usr/lib/php/20210902/timezonedb.so
-COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
-COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
+COPY --from=build /usr/local/bin/mydumper /usr/local/bin/myloader /usr/local/bin/
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.1/
 

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -26,7 +26,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.1-cli php8.1-fpm \
@@ -37,8 +37,8 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.1 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
-    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
+    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
     dpkg -i mydumper.deb && \
     rm mydumper.deb
 

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -12,11 +12,9 @@ RUN \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
     echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
-    tar -xzf mydumper.tar.gz && \
-    cd ./mydumper-0.16.3-6 && \
-    cmake . && \
-    make && \
-    make install && \
+    mkdir /mydumper && \
+    tar -xzf mydumper.tar.gz --strip-components=1 -C /mydumper && \
+    cd /mydumper && cmake . && make && make install && rm -rf /mydumper && rm -f mydumper.tar.gz && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04

--- a/php-fpm/Dockerfile.81
+++ b/php-fpm/Dockerfile.81
@@ -26,7 +26,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.1-cli php8.1-fpm \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -1,5 +1,3 @@
-FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
-
 FROM ubuntu:22.04 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -9,9 +7,16 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.2-dev php8.2-xml && \
+    eatmydata apt-get install -y php8.2-dev php8.2-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
+    curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
+    echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
+    tar -xzf mydumper.tar.gz && \
+    cd ./mydumper-0.16.3-6 && \
+    cmake . && \
+    make && \
+    make install && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04
@@ -28,7 +33,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client libmysqlclient21 openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.2-cli php8.2-fpm \
@@ -72,8 +77,7 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20220829/timezonedb.so /usr/lib/php/20220829/timezonedb.so
-COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
-COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
+COPY --from=build /usr/local/bin/mydumper /usr/local/bin/myloader /usr/local/bin/
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.2/
 

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -1,3 +1,5 @@
+FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
+
 FROM ubuntu:22.04 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -36,11 +38,7 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
-    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
-    dpkg -i mydumper.deb && \
-    rm mydumper.deb
+    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \
@@ -74,6 +72,8 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20220829/timezonedb.so /usr/lib/php/20220829/timezonedb.so
+COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
+COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.2/
 

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -7,7 +7,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.2-dev php8.2-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
+    eatmydata apt-get install -y php8.2-dev php8.2-xml g++cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -26,7 +26,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.2-cli php8.2-fpm \
@@ -36,13 +36,11 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm
-
-RUN curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
+    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
     echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
     dpkg -i mydumper.deb && \
     rm mydumper.deb
-
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -26,7 +26,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.2-cli php8.2-fpm \
@@ -37,8 +37,8 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
-    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
+    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
     dpkg -i mydumper.deb && \
     rm mydumper.deb
 

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -36,7 +36,11 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
+    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    dpkg -i mydumper.deb && \
+    rm mydumper.deb
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -7,7 +7,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.2-dev php8.2-xml g++cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
+    eatmydata apt-get install -y php8.2-dev php8.2-xml g++ cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -36,11 +36,13 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
+    ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm
+
+RUN curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
     echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
     dpkg -i mydumper.deb && \
     rm mydumper.deb
+
 
 RUN \
     usermod -d /home/www-data -s /bin/bash www-data && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -12,11 +12,9 @@ RUN \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
     echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
-    tar -xzf mydumper.tar.gz && \
-    cd ./mydumper-0.16.3-6 && \
-    cmake . && \
-    make && \
-    make install && \
+    mkdir /mydumper && \
+    tar -xzf mydumper.tar.gz --strip-components=1 -C /mydumper && \
+    cd /mydumper && cmake . && make && make install && rm -rf /mydumper && rm -f mydumper.tar.gz && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:22.04

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -36,7 +36,11 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm
+    ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
+    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    dpkg -i mydumper.deb && \
+    rm mydumper.deb
 
 RUN \
     deluser --remove-home --quiet ubuntu && \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -25,7 +25,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.3-cli php8.3-fpm \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -7,7 +7,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.3-dev php8.3-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
+    eatmydata apt-get install -y php8.3-dev php8.3-xml g++ cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -52,9 +52,8 @@ RUN \
     install -d -D -m 0755 -o www-data -g www-data /run/php && \
     install -d -D -m 0755 -o root -g root /usr/local/share
 
-#RUN \
-#    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-9.phar && chmod 0755 /usr/local/bin/phpunit && \
 RUN \
+    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-9.phar && chmod 0755 /usr/local/bin/phpunit && \
     wget -O /usr/local/bin/wp.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
         php -r '(new Phar("/usr/local/bin/wp.phar"))->extractTo("/usr/local/share/wp");' && \
         mv /usr/local/bin/wp.phar /usr/local/bin/wp && \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -12,11 +12,9 @@ RUN \
     pecl install timezonedb && \
     curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
     echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
-    tar -xzf mydumper.tar.gz && \
-    cd ./mydumper-0.16.3-6 && \
-    cmake . && \
-    make && \
-    make install && \
+    mkdir /mydumper && \
+    tar -xzf mydumper.tar.gz --strip-components=1 -C /mydumper && \
+    cd /mydumper && cmake . && make && make install && rm -rf /mydumper && rm -f mydumper.tar.gz && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -25,7 +25,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libglib2.0-dev libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.3-cli php8.3-fpm \
@@ -37,8 +37,8 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
     ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.bullseye_amd64.deb && \
-    echo "46c404eae9efab7928faf099c5b17a58 mydumper.deb" | md5sum -c - && \
+    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
+    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
     dpkg -i mydumper.deb && \
     rm mydumper.deb
 

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -1,3 +1,5 @@
+FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
+
 FROM ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -36,11 +38,7 @@ RUN \
     phpdismod ffi gettext readline sysvmsg xsl xdebug && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     eatmydata apt-get autoremove --purge -y && \
-    ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm && \
-    curl -L -o mydumper.deb https://github.com/mydumper/mydumper/releases/download/v0.16.3-6/mydumper_0.16.3-6.noble_amd64.deb && \
-    echo "36d4ff7a04356645d8a8a5a2771f5725 mydumper.deb" | md5sum -c - && \
-    dpkg -i mydumper.deb && \
-    rm mydumper.deb
+    ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm
 
 RUN \
     deluser --remove-home --quiet ubuntu && \
@@ -74,6 +72,8 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20230831/timezonedb.so /usr/lib/php/20230831/
+COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
+COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.3/
 

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -1,5 +1,3 @@
-FROM mydumper/mydumper:v0.16.3-6@sha256:0c808f42d93f847aef528d027263f49e45a49af142d4e6fd3b2d85b87914675f as mydumper_build
-
 FROM ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30 AS build
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -9,9 +7,16 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y php8.3-dev php8.3-xml && \
+    eatmydata apt-get install -y php8.3-dev php8.3-xml cmake make libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libzstd-dev libmysqlclient-dev && \
     eatmydata apt-get install -y php-pear --no-install-recommends && \
     pecl install timezonedb && \
+    curl -SL "https://github.com/mydumper/mydumper/archive/refs/tags/v0.16.3-6.tar.gz" -o mydumper.tar.gz && \
+    echo "6af51d6e18fdf318710ba0c3d87f6ac7 mydumper.tar.gz" | md5sum -c - && \
+    tar -xzf mydumper.tar.gz && \
+    cd ./mydumper-0.16.3-6 && \
+    cmake . && \
+    make && \
+    make install && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 FROM ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
@@ -27,7 +32,7 @@ RUN \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     eatmydata apt-get -q update && \
-    eatmydata apt-get install -y less git jq mysql-client openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
+    eatmydata apt-get install -y less git jq mysql-client libmysqlclient21 openssl wget vim nano libpcre3 libglib2.0-0 libatomic1 && \
     eatmydata apt-get install -y ghostscript msmtp --no-install-recommends && \
     eatmydata apt-get install -y --no-install-recommends \
         php8.3-cli php8.3-fpm \
@@ -47,8 +52,9 @@ RUN \
     install -d -D -m 0755 -o www-data -g www-data /run/php && \
     install -d -D -m 0755 -o root -g root /usr/local/share
 
+#RUN \
+#    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-9.phar && chmod 0755 /usr/local/bin/phpunit && \
 RUN \
-    wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-9.phar && chmod 0755 /usr/local/bin/phpunit && \
     wget -O /usr/local/bin/wp.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
         php -r '(new Phar("/usr/local/bin/wp.phar"))->extractTo("/usr/local/share/wp");' && \
         mv /usr/local/bin/wp.phar /usr/local/bin/wp && \
@@ -72,8 +78,7 @@ RUN \
     chmod +x /usr/bin/cron-control-runner
 
 COPY --from=build /usr/lib/php/20230831/timezonedb.so /usr/lib/php/20230831/
-COPY --from=mydumper_build /usr/local/bin/mydumper /usr/local/bin/mydumper
-COPY --from=mydumper_build /usr/local/bin/myloader /usr/local/bin/myloader
+COPY --from=build /usr/local/bin/mydumper /usr/local/bin/myloader /usr/local/bin/
 COPY rootfs/ /
 COPY rootfs-php/ /etc/php/8.3/
 

--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,6 +1,6 @@
 [
   {
-    "ref": "6.6",
+    "ref": "6.6.1",
     "tag": "6.6",
     "cacheable": true,
     "locked": true,


### PR DESCRIPTION
Gonna need mydumper support on vip-cli so here's what the code is for.

Currently testing it.

## Testing steps.

Steps assumes you have an environment created from `vip dev-env create`.

Also, I suggest running `vip dev-env` from your **sandbox**. Since we now have 70 GB on our sandbox, we can finally test these stuff there. The machine on your sandbox has way faster internet and likely to have even more cores, too.

1. Make sure your dev-env is down i.e. `vip dev-env stop --slug your-slug`
2. [Follow the readme](https://github.com/Automattic/vip-container-images#using-image-locally-in-dev-env) but apply the steps to the `php:` service in the `.yml` file.
3. Run `vip dev-env start --slug your-slug`
4. It should run without any errors
5. Then, execute `vip dev-env shell --slug your-slug`
6. Then, run `mydumper --version`. We should get `mydumper v0.16.3-6, built against MySQL 8.0.37 with SSL support`.

it should work fine for php8.3, 8.2, and 8.1.