### PR TITLE
ci: use the latest version of Trivy for security scans

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -128,17 +128,17 @@ runs:
         echo "filename=trivy-$(basename "${{ inputs.primaryTag }}" | tr '\\/:' '-').sarif" >> "${GITHUB_OUTPUT}"
 
     - name: Security Scan
-      uses: docker://aquasec/trivy:0.48.3
+      uses: docker://aquasec/trivy:0.55.2
       with:
         args: image --format json --ignore-unfixed --vuln-type os ${{ inputs.primaryTag }} --output trivy.json
 
     - name: Print report
-      uses: docker://aquasec/trivy:0.48.3
+      uses: docker://aquasec/trivy:0.55.2
       with:
         args: convert --format=table trivy.json
 
     - name: Generate SARIF
-      uses: docker://aquasec/trivy:0.48.3
+      uses: docker://aquasec/trivy:0.55.2
       with:
         args: convert --format=sarif --output=${{ steps.filename.outputs.filename }} trivy.json
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
@@ -151,7 +151,7 @@ runs:
       continue-on-error: true
 
     - name: Prepare markdown report
-      uses: docker://aquasec/trivy:0.48.3
+      uses: docker://aquasec/trivy:0.55.2
       with:
         args: convert --format=template --template=@.github/actions/build-docker-image/markdown.tpl --output=trivy.md trivy.json
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -149,6 +149,7 @@ runs:
           -v $(pwd):/workdir \
           -w /workdir \
           aquasec/trivy:0.55.2 image --format json --ignore-unfixed --pkg-types os ${{ inputs.primaryTag }} --output trivy.json
+        sudo chmod a+r -R .cache
 
     - name: Print report
       uses: docker://aquasec/trivy:0.55.2

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: The password to use for the registry
     required: false
     default: ${{ github.token }}
+  auth_token:
+    description: The token to authenticate with GitHub
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:
@@ -131,6 +135,8 @@ runs:
       uses: docker://aquasec/trivy:0.55.2
       with:
         args: image --format json --ignore-unfixed --vuln-type os ${{ inputs.primaryTag }} --output trivy.json
+      env:
+        ACTIONS_RUNTIME_TOKEN: ${{ inputs.auth_token }}
 
     - name: Print report
       uses: docker://aquasec/trivy:0.55.2

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -64,7 +64,6 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
-      if: ${{ inputs.push }}
 
     - name: Build and push container image
       uses: docker/build-push-action@v6
@@ -131,12 +130,25 @@ runs:
       run: |
         echo "filename=trivy-$(basename "${{ inputs.primaryTag }}" | tr '\\/:' '-').sarif" >> "${GITHUB_OUTPUT}"
 
-    - name: Security Scan
-      uses: docker://aquasec/trivy:0.55.2
+    - name: Create cache directory
+      shell: bash
+      run: mkdir -p .cache/trivy/db
+
+    - name: Cache Trivy database
+      uses: actions/cache@v4.0.2
       with:
-        args: image --format json --ignore-unfixed --vuln-type os ${{ inputs.primaryTag }} --output trivy.json
-      env:
-        ACTIONS_RUNTIME_TOKEN: ${{ inputs.auth_token }}
+        path: .cache/trivy/db
+        key: ${{ runner.os }}-trivy
+
+    - name: Security Scan
+      shell: bash
+      run: |
+        docker run --rm \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v $(pwd)/.cache:/root/.cache \
+          -v $(pwd):/workdir \
+          -w /workdir \
+          aquasec/trivy:0.55.2 image --format json --ignore-unfixed --pkg-types os ${{ inputs.primaryTag }} --output trivy.json
 
     - name: Print report
       uses: docker://aquasec/trivy:0.55.2


### PR DESCRIPTION
0.48.3 started to fail with:

```
2024-09-30T08:53:00.206Z	FATAL	init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 337.839µs, allowed: 44000/minute
```

Let's see if the latest version helps.