### PR TITLE
build(mu-plugins): use native platform image to prepare mu-plugins

### DIFF
--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -1,8 +1,9 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.20.3@sha256:90c4596fadb8a2f99c0aeb10aac6833126ae2cc18e8d2336d9067eb68595f61a AS build
+# syntax=docker/dockerfile:1.7
+FROM --platform=$BUILDPLATFORM ghcr.io/automattic/vip-container-images/alpine:3.20.3@sha256:90c4596fadb8a2f99c0aeb10aac6833126ae2cc18e8d2336d9067eb68595f61a AS build
 
 RUN apk add --no-cache git && mkdir -p /mu-plugins
-RUN git clone --depth 1 https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext
-RUN git clone --depth 1 --no-remote-submodules -b staging https://github.com/Automattic/vip-go-mu-plugins /mu-plugins-tmp
+RUN git clone --depth 1 --single-branch https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext
+RUN git clone --depth 1 --no-remote-submodules --single-branch -b staging https://github.com/Automattic/vip-go-mu-plugins /mu-plugins-tmp
 WORKDIR /mu-plugins-tmp
 RUN sed -i -e "s,git@github.com:,https://github.com/," .gitmodules && git submodule update --init --recursive --depth 1 --single-branch --jobs 8
 RUN gitsha=$(git rev-parse --short HEAD) && gitdate=$(git show -s --format=%cs "$gitsha") && date=$(date -d "$gitdate" '+%Y%m%d') && echo "{ \"tag\": \"staging\", \"stack_version\": \"${date}-${gitsha}\" }" > "/mu-plugins/.version"


### PR DESCRIPTION
In this PR, we modify the build process to use the staging image matching the build platform architecture. This is OK because we stage only platform-independent files.

This will make things slightly faster because the system will not have to use emulation for `git clone` and `rsync`.
