### PR TITLE
feat(traefik): build both v2 and v3

### DIFF
--- a/.github/workflows/traefik.yml
+++ b/.github/workflows/traefik.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Packages
+    name: Build Treafik ${{ matrix.traefik.suffix }} with OpenSSL
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -33,21 +33,30 @@ jobs:
       security-events: write
       id-token: write
       attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        traefik:
+          - suffix: "v2"
+            primaryTag: "latest"
+          - suffix: "v3"
+            primaryTag: "v3"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
 
       - name: Get image version
         id: getversion
-        run: echo "version=$(head -n 1 traefik/Dockerfile | sed -r -e 's/^([^:]+):([^ @$-]+).*/\2/')" >> "${GITHUB_OUTPUT}"
+        run: echo "version=$(head -n 1 "traefik/Dockerfile.${{ matrix.traefik.suffix }}" | sed -r -e 's/^([^:]+):([^ @$-]+).*/\2/')" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push image
         uses: ./.github/actions/build-docker-image
         with:
           context: traefik
+          file: traefik/Dockerfile.${{ matrix.traefik.suffix }}
           push: ${{ github.base_ref == null }}
-          cache-from: type=gha,scope=traefik
-          cache-to: type=gha,mode=max,scope=traefik
+          cache-from: type=gha,scope=traefik-${{ matrix.traefik.suffix }}
+          cache-to: type=gha,mode=max,scope=traefik-${{ matrix.traefik.suffix }}
           no-cache: ${{ github.event_name == 'workflow_dispatch' }}
-          primaryTag: ghcr.io/automattic/vip-container-images/traefik_openssl:${{ steps.getversion.outputs.version }}
-          tags: ghcr.io/automattic/vip-container-images/traefik_openssl:latest
+          primaryTag: ghcr.io/automattic/vip-container-images/traefik_openssl:${{ matrix.traefik.primaryTag }}
+          tags: ghcr.io/automattic/vip-container-images/traefik_openssl:${{ steps.getversion.outputs.version }}

--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,3 +1,0 @@
-FROM traefik:2.11.2@sha256:c6f6001dd1fc09fb0ae47ad2198102c40a8d9586c02d6040d561fd4fb7e91f45
-
-RUN apk upgrade --no-cache && apk add --no-cache openssl

--- a/traefik/Dockerfile.v2
+++ b/traefik/Dockerfile.v2
@@ -1,0 +1,3 @@
+FROM traefik:2.11.13@sha256:c9769cb5646ff62101899859932183f0da4e9da3ee2be8beebd0ea781584fa23
+
+RUN apk upgrade --no-cache && apk add --no-cache openssl

--- a/traefik/Dockerfile.v3
+++ b/traefik/Dockerfile.v3
@@ -1,0 +1,3 @@
+FROM traefik:v3.2.0@sha256:66e37237b371f2b25ce5f247cc371976929dcb18c041e05685f1de1df6422b72
+
+RUN apk upgrade --no-cache && apk add --no-cache openssl


### PR DESCRIPTION
Build both Traefik v2 and v3.

* Because we tagged the original `traefik` image as `latest`, we cannot just build v3 and call it `latest` because this will break old versions of VIP CLI (for Lando, there are incompatible changes in v3);
* The proposed solution is to keep `v2` as latest and tag `v3` as `v3`. Old versions of VIP CLI will continue to use the `latest` tag, while newer versions will use `v3`.