### PR TITLE
feat: reproducible builds

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -52,6 +52,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up Docker
+      uses: crazy-max/ghaction-setup-docker@v3
+      with:
+        daemon-config: |
+          {
+            "features": {
+              "containerd-snapshotter": true
+            }
+          }
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
@@ -72,8 +82,9 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
         platforms: ${{ inputs.platforms }}
-        push: ${{ inputs.push }}
-        sbom: true
+        outputs: |
+          type=docker,rewrite-timestamp=true
+          type=image,push=${{ inputs.push }},rewrite-timestamp=true
         tags: |
           ${{ inputs.primaryTag }}
           ${{ inputs.tags }}
@@ -81,6 +92,8 @@ runs:
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         no-cache: ${{ inputs.no-cache }}
+      env:
+        SOURCE_DATE_EPOCH: 0
 
     - name: Get image name
       shell: bash
@@ -111,18 +124,6 @@ runs:
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true
       if: inputs.push == 'true'
-
-    - name: Load image to local Docker
-      uses: docker/build-push-action@v6
-      with:
-        load: true
-        push: false
-        context: ${{ inputs.context }}
-        file: ${{ inputs.file }}
-        tags: |
-          ${{ inputs.primaryTag }}
-          ${{ inputs.tags }}
-        build-args: ${{ inputs.args }}
 
     - name: Generate filename for SARIF
       shell: bash
@@ -158,7 +159,7 @@ runs:
           -v $(pwd)/.cache:/root/.cache \
           -v $(pwd):/workdir \
           -w /workdir \
-          aquasec/trivy:0.56.1 image --format json --ignore-unfixed --pkg-types os --scanners vuln --db-repository ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2 ${{ inputs.primaryTag }} --output trivy.json
+          aquasec/trivy:0.57.1 image --format json --ignore-unfixed --pkg-types os --scanners vuln --db-repository ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2 ${{ inputs.primaryTag }} --output trivy.json
         sudo chmod a+r -R .cache
 
     - name: Calculate database hash
@@ -179,12 +180,12 @@ runs:
       if: steps.old_hash.outputs.hash != steps.new_hash.outputs.hash && steps.new_hash.outputs.hash != ''
 
     - name: Print report
-      uses: docker://aquasec/trivy:0.56.1
+      uses: docker://aquasec/trivy:0.57.1
       with:
         args: convert --format=table trivy.json
 
     - name: Generate SARIF
-      uses: docker://aquasec/trivy:0.56.1
+      uses: docker://aquasec/trivy:0.57.1
       with:
         args: convert --format=sarif --output=${{ steps.filename.outputs.filename }} trivy.json
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
@@ -197,7 +198,7 @@ runs:
       continue-on-error: true
 
     - name: Prepare markdown report
-      uses: docker://aquasec/trivy:0.56.1
+      uses: docker://aquasec/trivy:0.57.1
       with:
         args: convert --format=template --template=@.github/actions/build-docker-image/markdown.tpl --output=trivy.md trivy.json
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name


### PR DESCRIPTION
Whenever we rebuild an image (without a cache), its digest changes. If we push that image into a repository, this will cause rebuilds of dependent images.

Ref: https://docs.docker.com/build/ci/github-actions/reproducible-builds/
