### PR TITLE
fix: determine the correct Docker socket from the context

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -151,11 +151,16 @@ runs:
           echo "hash=" >> "${GITHUB_OUTPUT}"
         fi
 
+    - name: Get Docker socket
+      id: socket
+      run: echo docker_socket="$(docker context ls --format json | jq -r 'select(.Current == true) | .DockerEndpoint' | sed 's!^unix://!!')" >> "${GITHUB_OUTPUT}"
+      shell: bash
+
     - name: Security Scan
       shell: bash
       run: |
         docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v ${{ steps.socket.outputs.docker_socket }}:/var/run/docker.sock \
           -v $(pwd)/.cache:/root/.cache \
           -v $(pwd):/workdir \
           -w /workdir \


### PR DESCRIPTION
We pass the wrong socket to Trivy. The `crazy-max/ghaction-setup-docker` action creates its own context with a different socket. We get incorrect results because we pass `/var/run/docker.sock`.