### PR TITLE
refactor(skeleton): reduce image size

### DIFF
--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,8 +1,15 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.20.3@sha256:42ee5e50414b7c636fa5ee8b0d1c6b0219bb413285e4110178b16416711f52c9
+FROM alpine:3.20.3@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a AS build
 
-RUN apk add --no-cache --virtual build-deps git && \
-    git clone --depth=1 https://github.com/Automattic/vip-go-skeleton/ /clientcode && \
-    rm -rf /clientcode/.git && \
-    apk del --no-cache build-deps
+ENV SOURCE_DATE_EPOCH=0
 
-CMD ["sleep", "infinity"]
+RUN \
+    apk add --no-cache gcc git musl-dev && \
+    mkdir -p /target/bin && \
+    echo 'int main() { return 0; }' > /true.c && \
+    gcc -o /target/bin/true /true.c -Os -s -static && \
+    git clone --depth=1 https://github.com/Automattic/vip-go-skeleton/ /target/clientcode && \
+    rm -rf /target/clientcode/.git
+
+FROM scratch
+COPY --from=build /target /
+CMD ["/bin/true"]


### PR DESCRIPTION
Before: 38.8MB
After: 21.1MB

This will also reduce the number of mounts by one and improve startup time.

⚠️ Automattic/vip-cli#2135 must be merged and deployed first
