### PR TITLE
refactor(dev-tools): always update `/devtools`

### DIFF
--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,7 +1,9 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.21.0@sha256:32cff7c1b6fe35a9f3d0c829a5a29ca80761a19ae63c15c914bf4c03fbf7df66
+FROM ghcr.io/automattic/vip-container-images/helpers:v1@sha256:9f77c3da2ca0394d5846a9fc4195041f59ff5821ea6a7aaa43a08f15d28bf1eb AS helpers
+FROM busybox:stable-musl@sha256:0fc05e424940109068f4d6562b699da2563cd8521a35d7b216a5b0c51fb29281
 
-COPY setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools-orig/
-COPY setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools/
-COPY scripts /scripts
+COPY --from=helpers /rsync /usr/bin/rsync
+COPY --link setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools-orig/
+COPY --link setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools/
+COPY --link scripts /scripts
 
 ENTRYPOINT ["/usr/bin/rsync", "-a", "--delete", "/dev-tools-orig/", "/dev-tools/"]

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/automattic/vip-container-images/alpine:3.21.0@sha256:32cff7c1b6fe35a9f3d0c829a5a29ca80761a19ae63c15c914bf4c03fbf7df66
 
+COPY setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools-orig/
 COPY setup.sh add-site.sh dev-env-plugin.php wp-config* /dev-tools/
 COPY scripts /scripts
 
-CMD ["sleep", "infinity"]
+ENTRYPOINT ["/usr/bin/rsync", "-a", "--delete", "/dev-tools-orig/", "/dev-tools/"]


### PR DESCRIPTION
1. Copy dev-tools to both `/dev-tools-orig` and `/dev-tools` (the latter destination is required for backward compatibility).
2. When the container starts, sync tools from `/dev-tools-orig` to `/dev-tools`.

This will simplify the logic in VIP CLI (it will not have to find and remove devtools volume every time the environment starts) and ensure that the volume has the latest tools.

VIP CLI PR: Automattic/vip-cli#2139

Update:
3. Switch the base image from `alpine` to `busybox` and add a static build of `rsync`. This reduces the image size from 11.8MB to 3.05MB and eliminates the need to update the image weekly (`busybox` updates less often and has fewer security vulnerabilities than a full-fledged distro).
4. Make the build process more cache-friendly by [making copied files independent on their own layer](https://docs.docker.com/reference/dockerfile/#copy---link).
