### PR TITLE
refactor(mu-plugins): let entrypoint script terminate

### DIFF
--- a/mu-plugins/run.sh
+++ b/mu-plugins/run.sh
@@ -2,19 +2,6 @@
 
 if [ ! -f /shared/.version ] || ! cmp -s /shared/.version /mu-plugins/.version; then
     rm -f /shared/.version
-    if getent passwd www-data; then
-        CHOWN=--chown=www-data:www-data
-    else
-        CHOWN=
-    fi
-
-    rsync -a --delete-after --exclude='/.version' ${CHOWN} /mu-plugins/ /shared/
-
-    if [ -n "${CHOWN}" ]; then
-        install -m 0644 -o www-data -g www-data /mu-plugins/.version /shared/
-    else
-        cp /mu-plugins/.version /shared/
-    fi
+    rsync -a --delete-after --exclude='/.version' /mu-plugins/ /shared/
+    cp /mu-plugins/.version /shared/
 fi
-
-exec /bin/sleep infinity


### PR DESCRIPTION
Allow the entrypoint script to terminate to free up some resources.

The `vip-mu-plugins` service is [marked as `initOnly`](https://github.com/Automattic/vip-cli/blob/trunk/assets/dev-env.lando.template.yml.ejs#L210); therefore, this change is safe.

Related: Automattic/vip-cli#1341

Also, remove the `chown` logic because the image does not have the `www-data` user, and the condition is always false.
