### PR TITLE
refactor(skeleton): switch to `busybox` and simplify build

### DIFF
--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,8 +1,3 @@
-FROM ghcr.io/automattic/vip-container-images/alpine:3.21.0@sha256:32cff7c1b6fe35a9f3d0c829a5a29ca80761a19ae63c15c914bf4c03fbf7df66
+FROM busybox:stable-musl@sha256:0fc05e424940109068f4d6562b699da2563cd8521a35d7b216a5b0c51fb29281
 
-RUN apk add --no-cache --virtual build-deps git && \
-    git clone --depth=1 https://github.com/Automattic/vip-go-skeleton/ /clientcode && \
-    rm -rf /clientcode/.git && \
-    apk del --no-cache build-deps
-
-CMD ["sleep", "infinity"]
+ADD https://github.com/Automattic/vip-go-skeleton.git /clientcode

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox:stable-musl@sha256:0fc05e424940109068f4d6562b699da2563cd8521a35d7b216a5b0c51fb29281
 
-ADD https://github.com/Automattic/vip-go-skeleton.git /clientcode
+ADD --link https://github.com/Automattic/vip-go-skeleton.git /clientcode


### PR DESCRIPTION
This PR switches the base image for `skeleton` from `alpine` to `busybox`. This reduces the image size (22.5MB vs 32.9MB) and update frequency (the `busybox` binary is the only executable component of the image; it is updated less frequently and has much fewer vulnerabilities than a full-fledged image).

Also, because the `ADD` command can [add files from a Git repository](https://docs.docker.com/reference/dockerfile/#adding-files-from-a-git-repository), we simplify the build process by not using `git`. The build process will be faster because Docker does not need to execute anything in the foreign (emulated) architecture.

Unlike #984, this PR does not require changes to VIP CLI.
