### PR TITLE
ci: rename `crazy-max/ghaction-setup-docker` to `docker/setup-docker-action`

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -57,7 +57,7 @@ runs:
   using: composite
   steps:
     - name: Set up Docker
-      uses: crazy-max/ghaction-setup-docker@v4
+      uses: docker/setup-docker-action@01efb57f882e3b1a22e7cf3501dbe51287b0ecb4 # v4.0.0
       with:
         daemon-config: |
           {


### PR DESCRIPTION
See https://github.com/docker/setup-docker-action/releases/tag/v4.0.0

> Repo moved to [docker/setup-docker-action](https://github.com/docker/setup-docker-action)
