### PR TITLE
fix: disable Jetpack WAF

### DIFF
--- a/dev-tools/dev-env-plugin.php
+++ b/dev-tools/dev-env-plugin.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'DISABLE_JETPACK_WAF' ) ) {
+	define( 'DISABLE_JETPACK_WAF', true );
+}
+
 /******************
  * Handle HTTPS
  ******************/


### PR DESCRIPTION
This PR disables Jetpack's Web Application Firewall in local development environments.

Fixes: Automattic/vip-go-mu-plugins#6001
