### PR TITLE
refactor(wordpress): migrate to busybox

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -78,3 +78,4 @@ jobs:
           no-cache: ${{ matrix.wp.cacheable == false || github.event_name == 'workflow_dispatch' }}
           primaryTag: ghcr.io/automattic/vip-container-images/wordpress:${{ matrix.wp.tag }}
           tags: ${{ steps.extra-tags.outputs.tags }}
+          scan: false

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -4,5 +4,7 @@ ARG WP_GIT_REF
 ADD https://github.com/WordPress/WordPress.git#${WP_GIT_REF} /wp
 COPY extra/ /wp/
 
-FROM ghcr.io/automattic/vip-container-images/alpine:3.21.0@sha256:32cff7c1b6fe35a9f3d0c829a5a29ca80761a19ae63c15c914bf4c03fbf7df66
-COPY --from=build /wp /wp
+FROM ghcr.io/automattic/vip-container-images/helpers:v1@sha256:9f77c3da2ca0394d5846a9fc4195041f59ff5821ea6a7aaa43a08f15d28bf1eb AS helpers
+FROM busybox:stable-musl@sha256:0fc05e424940109068f4d6562b699da2563cd8521a35d7b216a5b0c51fb29281
+COPY --from=build --link /wp /wp
+COPY --from=helpers /rsync /usr/bin/rsync


### PR DESCRIPTION
This PR migrates WordPress images to `busybox`, resulting in smaller images and less frequent updates.
