### PR TITLE
Use archive instead of git repository when building WordPress

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -4,6 +4,8 @@ export XDEBUG_MODE=off
 
 subdomain=0
 
+echo -e "Welcome to the WordPress VIP! Setting things up..."
+
 # Check if the first argument starts with '--'
 if [ "${1#--}" != "$1" ]; then
   if [ $# -lt 8 ]; then

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.7
 FROM --platform=$BUILDPLATFORM scratch AS build
 ARG WP_GIT_REF
-ADD https://github.com/WordPress/WordPress.git#${WP_GIT_REF} /wp
+ADD https://github.com/WordPress/WordPress/archive/refs/tags/${WP_GIT_REF}.tar.gz /wp/
 COPY extra/ /wp/
 
 FROM ghcr.io/automattic/vip-container-images/helpers:v1@sha256:bc2beca042ce7c47e2b737920c77248f4a6c25cc7e137bf9de6944af8a68701c AS helpers
 FROM busybox:stable-musl@sha256:b4771ab006a5344931341972e1e4b1ff14db2c327eeab0053416aa2277213b1d
-COPY --from=build --link /wp /wp
+COPY --from=build --link --chown=1000:1000 /wp /wp
 COPY --from=helpers /rsync /usr/bin/rsync


### PR DESCRIPTION
This dramatically increases initial boot time in Windows and, to lesser extent, Mac OS.

Didn't test in Linux.

Steps to test: 

1. Check out the branch.
2. Build the image
```
cd wordpress
docker build --build-arg WP_GIT_REF=6.7.1 -t wordpress:gitless .
```
3. Create an env:
`vip dev-env create -s gitless < /dev/null`

4. Add local lando override:
```
services:
  wordpress:
    services:
      image: wordpress:copyless
      pull_policy: never
```

5. Start the env and note the time wordpress container took time to init.