### PR TITLE
Integrations config: fallback to empty array when $slug for the integrations is missing from integrations.json

### DIFF
--- a/wordpress/dev-tools/dev-env-plugin.php
+++ b/wordpress/dev-tools/dev-env-plugin.php
@@ -59,8 +59,8 @@ add_filter( 'vip_integrations_config_file_path', fn() => constant( 'WPVIP_INTEGR
 add_filter( 'vip_integrations_pre_load_config', function ( $config, $path, $slug ) {
 	if ( is_null( $config ) && is_readable( $path ) ) {
 		$json = json_decode( file_get_contents( $path ), true );
-		if ( is_array( $json ) && isset( $json[ $slug ] ) ) {
-			$config = $json[ $slug ];
+		if ( is_array( $json ) ) {
+			$config = $json[ $slug ] ?? [];
 		}
 	}
 


### PR DESCRIPTION
`null` resulted in printing of JSON. as a result of `require $config_path` 