### PR TITLE
fix(wordpress): set `SUNRISE` for multisite

### DIFF
--- a/wordpress/dev-tools/wp-config-multisite.php.tpl
+++ b/wordpress/dev-tools/wp-config-multisite.php.tpl
@@ -5,3 +5,4 @@ define( 'DOMAIN_CURRENT_SITE', '%DOMAIN%' );
 define( 'PATH_CURRENT_SITE', '/' );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
+define( 'SUNRISE', true );


### PR DESCRIPTION
Set `SUNRISE` to `true` for multisite installations.

See BB8-12188 and [Configuration for local development](https://docs.wpvip.com/wordpress-on-vip/multisites/sunrise-php/#h-configuration-for-local-development).
