### PR TITLE
chore: update traefik v3 to 3.3.3

### DIFF
--- a/traefik/Dockerfile.v3
+++ b/traefik/Dockerfile.v3
@@ -1,3 +1,3 @@
-FROM traefik:v3.2.3@sha256:efb87236c8c92599bcd3a67a7a8a55e0f255665f4719722bf398935aa9b92270
+FROM traefik:v3.3.3@sha256:f1fdee7fda041872cff24e36a08f45ca53f006ded88f743a8e30e3d87ca52b48
 
 RUN apk upgrade --no-cache && apk add --no-cache openssl


### PR DESCRIPTION
This addresses CVE-2024-13176.
