### PR TITLE
build: update actions

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -122,7 +122,7 @@ runs:
       if: inputs.push == 'true'
 
     - name: Attest provenance
-      uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+      uses: actions/attest-build-provenance@bd77c077858b8d561b7a36cbe48ef4cc642ca39d # v2.2.2
       with:
         subject-name: ${{ steps.imagename.outputs.image_name }}
         subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
* Bump `actions/cache` from 4.2.1 to 4.2.2 (#1094)
* Bump `actions/attest-build-provenance` from 2.2.0 to 2.2.2 (#1093)
* Bump `docker/setup-docker-action` from 4.1.0 to 4.2.0 (#1092)

