### PR TITLE
feat(wordpress): add support for environment variables

### DIFF
--- a/wordpress/dev-tools/setup.sh
+++ b/wordpress/dev-tools/setup.sh
@@ -204,3 +204,10 @@ if ! wp core is-installed --skip-plugins --skip-themes; then
 else
   echo "WordPress already installed"
 fi
+
+echo "Processing environment variables"
+for var in $(env | grep -E '^VIP_ENV_VAR_'); do
+  key=$(echo "${var}" | cut -d= -f1)
+  value="${key}"
+  wp config set --no-add --quiet "${key}" "${value}"
+done


### PR DESCRIPTION
Turn environment variables like `VIP_ENV_VAR_xxx` into PHP constants for compatibility with `vip_get_env_var()`.