### PR TITLE
fix(wordpress): env var processing

### DIFF
--- a/wordpress/dev-tools/setup.sh
+++ b/wordpress/dev-tools/setup.sh
@@ -209,5 +209,5 @@ echo "Processing environment variables"
 for var in $(env | grep -E '^VIP_ENV_VAR_'); do
   key=$(echo "${var}" | cut -d= -f1)
   value="${key}"
-  wp config set --no-add --quiet "${key}" "${value}"
+  wp config set --quiet "${key}" "${value}"
 done


### PR DESCRIPTION
If the constant corresponding to the environment variable does not exist in `wp-config.php`, the dev environment fails to start.

Related: PLTFRM-590
