### PR TITLE
chore(deps): update `alpine` base image to 3.22.1

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
 # Common packages needed for most images
 # - rsync: Needed to copy code to k8s/docker-compose volumes

--- a/photon/Dockerfile
+++ b/photon/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS build
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS build
 RUN apk add --no-cache php82-dev php82-pear php82-openssl gcc make libc-dev graphicsmagick-dev libtool subversion
 RUN pecl82 channel-update pecl.php.net
 RUN pecl82 install channel://pecl.php.net/gmagick-2.0.6RC1 < /dev/null
@@ -7,7 +7,7 @@ RUN \
     svn co https://code.svn.wordpress.org/photon/ /usr/share/webapps/photon -r645 && \
     rm -rf /usr/share/webapps/photon/.svn /usr/share/webapps/photon/tests
 
-FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 RUN \
     apk upgrade --no-cache && \
     apk add --no-cache \


### PR DESCRIPTION
This pull request updates the base Alpine image version across multiple Dockerfiles to ensure the use of the latest patch release for improved security and stability.

### Dockerfile updates:

* Updated the base image in `alpine/Dockerfile` from `alpine:3.22.0` to `alpine:3.22.1` to incorporate the latest updates and security fixes.
* Updated the base image in `photon/Dockerfile` for both build and runtime stages from `alpine:3.22.0` to `alpine:3.22.1`, ensuring consistency and leveraging the latest Alpine improvements. [[1]](diffhunk://#diff-4df650c90586f78b0769e6a54876a4b0d037f00eaef773ca3ffa2eb896aa3d4dL1-R1) [[2]](diffhunk://#diff-4df650c90586f78b0769e6a54876a4b0d037f00eaef773ca3ffa2eb896aa3d4dL10-R10)