### PR TITLE
fix(php-helpers): incorrect stage name

### DIFF
--- a/php-helpers/docker-bake.hcl
+++ b/php-helpers/docker-bake.hcl
@@ -18,7 +18,7 @@ target "base" {
 
 target "mydumper" {
   inherits = ["base"]
-  target   = "mydumper"
+  target   = "build-mydumper"
 }
 
 target "php81" {


### PR DESCRIPTION
This pull request includes a bugfix to the `php-helpers/docker-bake.hcl` file. The change updates the `target` value for the `mydumper` target to use `build-mydumper` instead of `mydumper` to match the `Dockerfile`.