### PR TITLE
Disable Jetpack Account Protection by default on Local Dev Envs

### DIFF
--- a/wordpress/dev-tools/wp-config-defaults.php
+++ b/wordpress/dev-tools/wp-config-defaults.php
@@ -179,3 +179,8 @@ if ( ! defined( 'JETPACK_STAGING_MODE' ) ) {
 if ( 'Windows' !== PHP_OS_FAMILY ) {
 	ini_set( 'error_log', '/dev/stderr' );
 }
+
+// Disable Jetpack Account Protection by default on local development environments
+if ( defined( 'VIP_GO_APP_ENVIRONMENT') && VIP_GO_APP_ENVIRONMENT === 'local' ) {
+	define( 'DISABLE_JETPACK_ACCOUNT_PROTECTION', true )
+}


### PR DESCRIPTION
The default password for the admin user is "password" which ends up immediately getting flagged by Jetpack as a compromised password.

It would be nice to provide a way to not have this default password flagged.