### PR TITLE
fix(wp-test-runner): `db.php` download URL

### DIFF
--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -58,7 +58,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 		php8.3-cli php8.3-apcu php8.3-curl php8.3-gd php8.3-gmp php8.3-igbinary php8.3-imagick php8.3-imap php8.3-intl php8.3-mbstring php8.3-mysql php8.3-sqlite3 php8.3-xdebug php8.3-xml            php8.3-zip php8.3-memcache php8.3-memcached \
 		php8.4-cli php8.4-apcu php8.4-curl php8.4-gd php8.4-gmp php8.4-igbinary php8.4-imagick php8.4-imap php8.4-intl php8.4-mbstring php8.4-mysql php8.4-sqlite3 php8.4-xdebug php8.4-xml            php8.4-zip php8.4-memcache php8.4-memcached && \
 	echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/ubuntu" && \
-	chmod 0440 "/etc/sudoers.d/ubuntu" && \	echo "xdebug.mode=coverage" | tee -a /etc/php/*/mods-available/xdebug.ini && \
+	chmod 0440 "/etc/sudoers.d/ubuntu" && \
+	echo "xdebug.mode=coverage" | tee -a /etc/php/*/mods-available/xdebug.ini && \
 	update-alternatives --set php /usr/bin/php8.2 && \
 	wget https://getcomposer.org/installer -qO - | php -- --install-dir=/usr/bin/ --filename=composer
 

--- a/wp-test-runner/install-wp
+++ b/wp-test-runner/install-wp
@@ -41,7 +41,7 @@ download_wp() {
 			mkdir -p "/wordpress/wordpress-${VERSION}"
 			wget -q "https://wordpress.org/wordpress-${VERSION}.tar.gz" -O - | tar --strip-components=1 -zxm -f - -C "/wordpress/wordpress-${VERSION}"
 		fi
-		wget -q https://raw.github.com/markoheijnen/wp-mysqli/master/db.php -O "/wordpress/wordpress-${VERSION}/wp-content/db.php"
+		wget -q https://raw.githubusercontent.com/markoheijnen/wp-mysqli/refs/heads/master/db.php -O "/wordpress/wordpress-${VERSION}/wp-content/db.php"
 	else
 		echo "Skipping WordPress download"
 	fi


### PR DESCRIPTION
This pull request makes two small but important updates to the WordPress test runner setup. The first change fixes the URL used to download the `db.php` file for WordPress, ensuring compatibility with the latest GitHub URL structure. The second change improves the Dockerfile by splitting a chained command for better readability and maintainability.

**WordPress installation script update:**
- Updated the URL in the `install-wp` script to use the correct GitHub path for downloading `db.php`, switching from the deprecated `raw.github.com` to `raw.githubusercontent.com` and specifying the branch path.

**Dockerfile improvements:**
- Split the chained command that sets file permissions and appends to `xdebug.ini` into two separate lines in the `wp-test-runner/Dockerfile`, improving clarity and maintainability.