### PR TITLE
Update WordPress version references in JSON

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -7,43 +7,29 @@
     "prerelease": false
   },
   {
-    "ref": "6.7.3",
+    "ref": "6.7.4",
     "tag": "6.7",
     "cacheable": true,
     "locked": true,
     "prerelease": false
   },
   {
-    "ref": "6.6.3",
+    "ref": "6.6.4",
     "tag": "6.6",
     "cacheable": true,
     "locked": true,
     "prerelease": false
   },
   {
-    "ref": "6.5.6",
+    "ref": "6.5.7",
     "tag": "6.5",
     "cacheable": true,
     "locked": true,
     "prerelease": false
   },
   {
-    "ref": "6.4.6",
+    "ref": "6.4.7",
     "tag": "6.4",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
-    "ref": "6.3.6",
-    "tag": "6.3",
-    "cacheable": true,
-    "locked": true,
-    "prerelease": false
-  },
-  {
-    "ref": "6.2.7",
-    "tag": "6.2",
     "cacheable": true,
     "locked": true,
     "prerelease": false


### PR DESCRIPTION
This pull request updates the supported WordPress versions in the `wordpress/versions.json` file to reflect the latest patch releases and removes support for older minor versions.

WordPress version updates:

* Updated the `ref` values for versions `6.7`, `6.6`, `6.5`, and `6.4` to their latest patch releases: `6.7.4`, `6.6.4`, `6.5.7`, and `6.4.7` respectively.

Version deprecations:

* Removed support for older minor versions `6.3.6` and `6.2.7` from the list.