### PR TITLE
feat(php-helpers): add support for PHP 8.5

### DIFF
--- a/php-helpers/Dockerfile
+++ b/php-helpers/Dockerfile
@@ -104,6 +104,17 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 
+FROM --platform=${BUILDPLATFORM} php-common AS php85
+WORKDIR /src/timezonedb
+RUN \
+    xx-apt-get update && \
+    xx-apt-get install -y --no-install-recommends php8.5-dev && \
+    phpize && ./configure --host=$(xx-clang --print-target-triple) && make -j$(nproc) && make install && \
+    make distclean && \
+    xx-apt-get remove --purge -y --auto-remove php8.5-dev && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+
 
 FROM scratch
 COPY --from=build-mydumper /usr/local/bin/mydumper /usr/local/bin/myloader /etc/mydumper.cnf /

--- a/php-helpers/docker-bake.hcl
+++ b/php-helpers/docker-bake.hcl
@@ -41,6 +41,11 @@ target "php84" {
   target   = "php84"
 }
 
+target "php85" {
+  inherits = ["base"]
+  target   = "php85"
+}
+
 target "default" {
   inherits = ["base"]
   output = [


### PR DESCRIPTION
This pull request adds support for PHP 8.5 to the build process in the `php-helpers` directory. The main changes involve introducing a new build stage in the Dockerfile for PHP 8.5 and updating the build configuration to include this new target.

**Build system updates for PHP 8.5 support:**

* Added a new `php85` build stage to the `php-helpers/Dockerfile` to build and install the `timezonedb` extension for PHP 8.5.
* Updated `php-helpers/docker-bake.hcl` to define a new `php85` build target, inheriting from the base configuration.