### PR TITLE
chore: update Alpine Linux base image to 3.23.4

### DIFF
--- a/helpers/Dockerfile
+++ b/helpers/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=${BUILDPLATFORM} tonistiigi/xx:latest@sha256:923441d7c25f1e2eb5789f82d987693c47b8ed987c4ab3b075d6ed2b5d6779a3 AS xx
 
-FROM --platform=${BUILDPLATFORM} alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS common
+FROM --platform=${BUILDPLATFORM} alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS common
 COPY --from=xx / /
 
 RUN apk add --no-cache clang file gawk lld make pkgconf

--- a/mu-plugins/Dockerfile
+++ b/mu-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM --platform=$BUILDPLATFORM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS build
+FROM --platform=$BUILDPLATFORM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS build
 
 RUN apk add --no-cache git rsync && mkdir -p /mu-plugins
 RUN git clone --depth 1 --single-branch https://github.com/Automattic/vip-go-mu-plugins-ext /mu-plugins-ext

--- a/photon/Dockerfile
+++ b/photon/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS build
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS build
 RUN apk add --no-cache php83-dev php83-pear php83-openssl gcc make libc-dev graphicsmagick-dev libtool subversion
 RUN pecl83 channel-update pecl.php.net
 RUN pecl83 install channel://pecl.php.net/gmagick-2.0.6RC1 < /dev/null
@@ -7,7 +7,7 @@ RUN \
     svn co https://code.svn.wordpress.org/photon/ /usr/share/webapps/photon -r645 && \
     rm -rf /usr/share/webapps/photon/.svn /usr/share/webapps/photon/tests
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 RUN \
     apk upgrade --no-cache && \
     apk add --no-cache \


### PR DESCRIPTION
This pull request updates the Alpine Linux base image version used in multiple Dockerfiles across the project. The main change is the upgrade from Alpine 3.23.3 to Alpine 3.23.4, which includes security patches and upstream bug fixes.

**Base image updates:**

* Updated the base image in `helpers/Dockerfile` from `alpine:3.23.3` to `alpine:3.23.4` for the `common` stage, ensuring the latest security updates are included.
* Updated the base image in `mu-plugins/Dockerfile` from `alpine:3.23.3` to `alpine:3.23.4` for the `build` stage.
* Updated both the `build` and final stages in `photon/Dockerfile` to use `alpine:3.23.4` instead of `alpine:3.23.3`. [[1]](diffhunk://#diff-4df650c90586f78b0769e6a54876a4b0d037f00eaef773ca3ffa2eb896aa3d4dL1-R1) [[2]](diffhunk://#diff-4df650c90586f78b0769e6a54876a4b0d037f00eaef773ca3ffa2eb896aa3d4dL10-R10)

These updates help keep the project secure and up to date with the latest Alpine Linux improvements.