### PR TITLE
refactor(php-fpm): migrate to Debian Bookworm to fix build failures

### DIFF
--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -13,6 +13,7 @@ RUN \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
     curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    echo '7511384559c9ddf1d5ce5f60be429ae9d4e7d01d9480d6f1b7a30c0810cf8b60  /tmp/debsuryorg-archive-keyring.deb' | sha256sum -c - && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
     rm -f /tmp/debsuryorg-archive-keyring.deb && \
     CODENAME="$(lsb_release -sc)" && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
-FROM ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02
+FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 
 # Extra PHP extensions: msgpack (because of memcache)
@@ -12,11 +12,15 @@ RUN \
     export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so && \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
-    echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
+    curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+    rm -f /tmp/debsuryorg-archive-keyring.deb && \
+    CODENAME="$(lsb_release -sc)" && \
+    echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
     curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     apt-get -q update && \
     apt-get install -y --no-install-recommends \
-        ghostscript git jq less libatomic1 libglib2.0-0 libmysqlclient21 libpcre3 msmtp mysql-client \
+        ghostscript git jq less libatomic1 libglib2.0-0 libmariadb3 libpcre3 msmtp mariadb-client \
         nano openssl vim wget zstd && \
     apt-get install -y --no-install-recommends \
         php8.2-apcu php8.2-bcmath php8.2-cli php8.2-curl php8.2-fpm php8.2-gd php8.2-gmagick php8.2-gmp php8.2-gnupg \
@@ -27,7 +31,6 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     ln -s /usr/sbin/php-fpm8.2 /usr/sbin/php-fpm && \
     \
-    deluser --remove-home --quiet ubuntu && \
     usermod -d /home/www-data -s /bin/bash www-data && \
     install -d -D -m 0750 -o www-data -g www-data /home/www-data && \
     install -d -D -m 0777 -o www-data -g www-data /var/www/html && \

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
+FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
 FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 

--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -17,7 +17,6 @@ RUN \
     rm -f /tmp/debsuryorg-archive-keyring.deb && \
     CODENAME="$(lsb_release -sc)" && \
     echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
-    curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
     apt-get -q update && \
     apt-get install -y --no-install-recommends \
         ghostscript git jq less libatomic1 libglib2.0-0 libmariadb3 libpcre3 msmtp mariadb-client \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -12,6 +12,7 @@ RUN \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
     curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    echo '7511384559c9ddf1d5ce5f60be429ae9d4e7d01d9480d6f1b7a30c0810cf8b60  /tmp/debsuryorg-archive-keyring.deb' | sha256sum -c - && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
     rm -f /tmp/debsuryorg-archive-keyring.deb && \
     CODENAME="$(lsb_release -sc)" && \

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
+FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
 FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
-FROM ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02
+FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 
 # We lack: newrelic
@@ -11,11 +11,14 @@ RUN \
     export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so && \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
-    echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
-    curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
+    curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+    rm -f /tmp/debsuryorg-archive-keyring.deb && \
+    CODENAME="$(lsb_release -sc)" && \
+    echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
     apt-get -q update && \
     apt-get install -y --no-install-recommends \
-        ghostscript git jq less libatomic1 libglib2.0-0 libmysqlclient21 libpcre3 msmtp mysql-client \
+        ghostscript git jq less libatomic1 libglib2.0-0 libmariadb3 libpcre3 msmtp mariadb-client \
         nano openssl vim wget zstd && \
     apt-get install -y --no-install-recommends \
         php8.3-apcu php8.3-bcmath php8.3-cli php8.3-curl php8.3-fpm php8.3-gd php8.3-gmagick php8.3-gmp php8.3-gnupg \
@@ -26,7 +29,6 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     ln -s /usr/sbin/php-fpm8.3 /usr/sbin/php-fpm && \
     \
-    deluser --remove-home --quiet ubuntu && \
     usermod -d /home/www-data -s /bin/bash www-data && \
     install -d -D -m 0750 -o www-data -g www-data /home/www-data && \
     install -d -D -m 0777 -o www-data -g www-data /var/www/html && \

--- a/php-fpm/Dockerfile.84
+++ b/php-fpm/Dockerfile.84
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
-FROM ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02
+FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 
 # We lack: newrelic
@@ -11,11 +11,14 @@ RUN \
     export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so && \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
-    echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
-    curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
+    curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+    rm -f /tmp/debsuryorg-archive-keyring.deb && \
+    CODENAME="$(lsb_release -sc)" && \
+    echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
     apt-get -q update && \
     apt-get install -y --no-install-recommends \
-        ghostscript git jq less libatomic1 libglib2.0-0 libmysqlclient21 libpcre3 msmtp mysql-client \
+        ghostscript git jq less libatomic1 libglib2.0-0 libmariadb3 libpcre3 msmtp mariadb-client \
         nano openssl vim wget zstd && \
     apt-get install -y --no-install-recommends \
         php8.4-apcu php8.4-bcmath php8.4-cli php8.4-curl php8.4-fpm php8.4-gd php8.4-gmagick php8.4-gmp php8.4-gnupg \
@@ -26,7 +29,6 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     ln -s /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm && \
     \
-    deluser --remove-home --quiet ubuntu && \
     usermod -d /home/www-data -s /bin/bash www-data && \
     install -d -D -m 0750 -o www-data -g www-data /home/www-data && \
     install -d -D -m 0777 -o www-data -g www-data /var/www/html && \

--- a/php-fpm/Dockerfile.84
+++ b/php-fpm/Dockerfile.84
@@ -12,6 +12,7 @@ RUN \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
     curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    echo '7511384559c9ddf1d5ce5f60be429ae9d4e7d01d9480d6f1b7a30c0810cf8b60  /tmp/debsuryorg-archive-keyring.deb' | sha256sum -c - && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
     rm -f /tmp/debsuryorg-archive-keyring.deb && \
     CODENAME="$(lsb_release -sc)" && \

--- a/php-fpm/Dockerfile.84
+++ b/php-fpm/Dockerfile.84
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
+FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
 FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 

--- a/php-fpm/Dockerfile.85
+++ b/php-fpm/Dockerfile.85
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
-FROM ubuntu:24.04@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54
+FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 
 # We lack: newrelic
@@ -11,17 +11,16 @@ RUN \
     export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so && \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
-    echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
-    curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
+    curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+    rm -f /tmp/debsuryorg-archive-keyring.deb && \
+    CODENAME="$(lsb_release -sc)" && \
+    echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
     apt-get -q update && \
     apt-get install -y --no-install-recommends \
-        ghostscript git jq less libatomic1 libglib2.0-0 libmysqlclient21 libpcre3 msmtp mysql-client \
+        ghostscript git jq less libatomic1 libglib2.0-0 libmariadb3 libpcre3 msmtp mariadb-client \
         nano openssl vim wget zstd && \
-    apt-get install -y --no-install-recommends libmemcached11t64 && \
-    # apt-get install -y --no-install-recommends \
-    #     php8.5-apcu php8.5-bcmath php8.5-cli php8.5-curl php8.5-fpm php8.5-gd php8.5-gmagick php8.5-gmp php8.5-gnupg \
-    #     php8.5-igbinary php8.5-intl php8.5-mbstring php8.5-mcrypt php8.5-memcache php8.5-memcached php8.5-mysql \
-    #     php8.5-soap php8.5-sqlite3 php8.5-ssh2 php8.5-xdebug php8.5-xml php8.5-zip && \
+    apt-get install -y --no-install-recommends libmemcached11 && \
     apt-get install -y --no-install-recommends \
         php8.5-apcu php8.5-bcmath php8.5-cli php8.5-curl php8.5-fpm php8.5-gd php8.5-gmagick php8.5-gmp php8.5-gnupg \
         php8.5-igbinary php8.5-intl php8.5-mbstring php8.5-mcrypt php8.5-memcached php8.5-mysql \
@@ -33,7 +32,6 @@ RUN \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     ln -s /usr/sbin/php-fpm8.5 /usr/sbin/php-fpm && \
     \
-    deluser --remove-home --quiet ubuntu && \
     usermod -d /home/www-data -s /bin/bash www-data && \
     install -d -D -m 0750 -o www-data -g www-data /home/www-data && \
     install -d -D -m 0777 -o www-data -g www-data /var/www/html && \

--- a/php-fpm/Dockerfile.85
+++ b/php-fpm/Dockerfile.85
@@ -12,6 +12,7 @@ RUN \
     apt-get -y upgrade && \
     apt-get install -y curl lsb-release ca-certificates gnupg --no-install-recommends && \
     curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    echo '7511384559c9ddf1d5ce5f60be429ae9d4e7d01d9480d6f1b7a30c0810cf8b60  /tmp/debsuryorg-archive-keyring.deb' | sha256sum -c - && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
     rm -f /tmp/debsuryorg-archive-keyring.deb && \
     CODENAME="$(lsb_release -sc)" && \

--- a/php-fpm/Dockerfile.85
+++ b/php-fpm/Dockerfile.85
@@ -1,4 +1,4 @@
-FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:fb5d4a8d718b8e056cf2db62ebe0a817155c34d5af5d66bd7296ec59e4327c84 AS build
+FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
 FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
 ARG TARGETARCH
 


### PR DESCRIPTION
This pull request updates the PHP-FPM Dockerfiles for versions 8.2, 8.3, 8.4, and 8.5 to use Debian Bookworm as the base image instead of Ubuntu, switches PHP package sources to Sury, and makes related dependency adjustments. These changes improve consistency, security, and package availability for PHP builds.

**Base image and package source migration:**

* Changed the base image from `ubuntu:24.04` to `debian:bookworm` in all Dockerfiles (`Dockerfile.82`, `Dockerfile.83`, `Dockerfile.84`, `Dockerfile.85`). [[1]](diffhunk://#diff-16cbaca8e56478d4d52f29355d40ae329aaf83cd0c0b566d532fd48689960f93L1-R2) [[2]](diffhunk://#diff-84349a488d5017189ade4b1e143a3f1832343a2abfd8a1c36ef4a1f71fe73c20L1-R2) [[3]](diffhunk://#diff-12279e235e5f547ac6124f25eec4b60c7f258b9b208a4d9d5b1b9369a2768928L1-R2) [[4]](diffhunk://#diff-cc0dad0c8531de1502f87313ecb89297a65e209b17ba6aba09fab15a4ba30604L1-R2)
* Switched PHP package source from the Ondřej Surý Ubuntu PPA to the official Sury Debian repository, including the setup of the Sury archive keyring and repository configuration. [[1]](diffhunk://#diff-16cbaca8e56478d4d52f29355d40ae329aaf83cd0c0b566d532fd48689960f93L15-R22) [[2]](diffhunk://#diff-84349a488d5017189ade4b1e143a3f1832343a2abfd8a1c36ef4a1f71fe73c20L14-R21) [[3]](diffhunk://#diff-12279e235e5f547ac6124f25eec4b60c7f258b9b208a4d9d5b1b9369a2768928L14-R21) [[4]](diffhunk://#diff-cc0dad0c8531de1502f87313ecb89297a65e209b17ba6aba09fab15a4ba30604L14-R23)

**Dependency and package adjustments:**

* Replaced `libmysqlclient21` and `mysql-client` with `libmariadb3` and `mariadb-client` to match the Debian ecosystem. [[1]](diffhunk://#diff-16cbaca8e56478d4d52f29355d40ae329aaf83cd0c0b566d532fd48689960f93L15-R22) [[2]](diffhunk://#diff-84349a488d5017189ade4b1e143a3f1832343a2abfd8a1c36ef4a1f71fe73c20L14-R21) [[3]](diffhunk://#diff-12279e235e5f547ac6124f25eec4b60c7f258b9b208a4d9d5b1b9369a2768928L14-R21) [[4]](diffhunk://#diff-cc0dad0c8531de1502f87313ecb89297a65e209b17ba6aba09fab15a4ba30604L14-R23)
* Updated `libmemcached11t64` to `libmemcached11` in `Dockerfile.85` to match package naming on Debian Bookworm.

**Cleanup and minor changes:**

* Removed the `deluser --remove-home --quiet ubuntu` line, as the `ubuntu` user does not exist in the new base image. [[1]](diffhunk://#diff-16cbaca8e56478d4d52f29355d40ae329aaf83cd0c0b566d532fd48689960f93L30) [[2]](diffhunk://#diff-84349a488d5017189ade4b1e143a3f1832343a2abfd8a1c36ef4a1f71fe73c20L29) [[3]](diffhunk://#diff-12279e235e5f547ac6124f25eec4b60c7f258b9b208a4d9d5b1b9369a2768928L29) [[4]](diffhunk://#diff-cc0dad0c8531de1502f87313ecb89297a65e209b17ba6aba09fab15a4ba30604L36)