### PR TITLE
refactor(wp-test-runner): migrate to Bookworm

### DIFF
--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Base Image #
 ##############
-FROM ubuntu:noble AS base
+FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc AS base
 RUN \
 	rm -f /etc/apt/apt.conf.d/docker-clean && \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
@@ -14,12 +14,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 	apt-get -y install eatmydata && \
 	mkdir -p /usr/lib/libeatmydata && ln -s -t /usr/lib/libeatmydata/ /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so* && \
 	export LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so && \
-	apt-get install -y --no-install-recommends ca-certificates curl gnupg2 jq lsb-release subversion unzip wget && \
+	apt-get install -y --no-install-recommends ca-certificates curl jq lsb-release subversion unzip wget && \
+	curl -SLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+	echo '7511384559c9ddf1d5ce5f60be429ae9d4e7d01d9480d6f1b7a30c0810cf8b60  /tmp/debsuryorg-archive-keyring.deb' | sha256sum -c - && \
+	dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+	rm -f /tmp/debsuryorg-archive-keyring.deb && \
 	CODENAME="$(lsb_release -sc)" && \
-	echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
-	curl -sSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x71DAEAAB4AD4CAB6" | gpg --dearmor > /etc/apt/trusted.gpg.d/ppa-ondrej-php.gpg && \
+	echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ ${CODENAME} main" > /etc/apt/sources.list.d/php.list && \
 	apt-get update && \
-	apt-get -y upgrade
+	apt-get -y upgrade && \
+	useradd -m -s /bin/bash debian
 
 ENV LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so
 
@@ -28,10 +32,10 @@ ENV LD_PRELOAD=/usr/lib/libeatmydata/libeatmydata.so
 # WordPress Image #
 ###################
 FROM --platform=$BUILDPLATFORM base AS build-wp
-RUN install -d -o ubuntu -g ubuntu -m 0777 /wordpress
+RUN install -d -o debian -g debian -m 0777 /wordpress
 COPY install-wp /usr/local/bin/
 
-USER ubuntu
+USER debian
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 RUN \
 	set -ex; \
@@ -56,8 +60,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 		php8.3-cli php8.3-apcu php8.3-curl php8.3-gd php8.3-gmp php8.3-igbinary php8.3-imagick php8.3-imap php8.3-intl php8.3-mbstring php8.3-mysql php8.3-sqlite3 php8.3-xdebug php8.3-xml php8.3-zip php8.3-memcache php8.3-memcached \
 		php8.4-cli php8.4-apcu php8.4-curl php8.4-gd php8.4-gmp php8.4-igbinary php8.4-imagick php8.4-imap php8.4-intl php8.4-mbstring php8.4-mysql php8.4-sqlite3 php8.4-xdebug php8.4-xml php8.4-zip php8.4-memcache php8.4-memcached \
 		php8.5-cli php8.5-apcu php8.5-curl php8.5-gd php8.5-gmp php8.5-igbinary php8.5-imagick php8.5-imap php8.5-intl php8.5-mbstring php8.5-mysql php8.5-sqlite3 php8.5-xdebug php8.5-xml php8.5-zip                 php8.5-memcached && \
-	echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/ubuntu" && \
-	chmod 0440 "/etc/sudoers.d/ubuntu" && \
+	echo "debian ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/debian" && \
+	chmod 0440 "/etc/sudoers.d/debian" && \
 	echo "xdebug.mode=coverage" | tee -a /etc/php/*/mods-available/xdebug.ini && \
 	update-alternatives --set php /usr/bin/php8.3 && \
 	wget https://getcomposer.org/installer -qO - | php -- --install-dir=/usr/bin/ --filename=composer
@@ -69,16 +73,16 @@ COPY create-database configure-environment install-wp runner /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/runner"]
 
 # Compatibility
-RUN ln -s /home/ubuntu /home/circleci && install -d -m 0777 -o ubuntu -g ubuntu /home/ubuntu/project
+RUN ln -s /home/debian /home/circleci && install -d -m 0777 -o debian -g debian /home/debian/project
 
-USER ubuntu
-COPY --from=build-wp --chown=ubuntu:ubuntu /home/ubuntu/.nvm /home/ubuntu/.nvm
-COPY --from=build-wp --chown=ubuntu:ubuntu /wordpress /wordpress
-ENV NVM_DIR=/home/ubuntu/.nvm
+USER debian
+COPY --from=build-wp --chown=debian:debian /home/debian/.nvm /home/debian/.nvm
+COPY --from=build-wp --chown=debian:debian /wordpress /wordpress
+ENV NVM_DIR=/home/debian/.nvm
 RUN \
 	set +x && \
 	. "${NVM_DIR}/nvm.sh" && \
 	nvm install --lts && \
 	nvm use --lts
 
-WORKDIR /home/ubuntu/project
+WORKDIR /home/debian/project

--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Base Image #
 ##############
-FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc AS base
+FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 AS base
 RUN \
 	rm -f /etc/apt/apt.conf.d/docker-clean && \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \

--- a/wp-test-runner/configure-environment
+++ b/wp-test-runner/configure-environment
@@ -10,7 +10,7 @@ set -e
 : "${PHPUNIT_VERSION:=""}"
 : "${PHP_VERSION:="8.3"}"
 : "${DISABLE_XDEBUG:=""}"
-: "${APP_HOME:="/home/circleci/project"}"
+: "${APP_HOME:="/home/debian/project"}"
 : "${PHP_OPTIONS:=""}"
 
 if [ ! -d "/wordpress/wordpress-${WP_VERSION}" ] || [ ! -d "/wordpress/wordpress-tests-lib-${WP_VERSION}" ]; then
@@ -49,8 +49,8 @@ if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
     PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
 elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
     PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
-elif [ -x "${APP_HOME}/vendor/bin/phpunit" ]; then
-	PHPUNIT=~/.composer/vendor/bin/phpunit
+elif [ -x "${HOME}/vendor/bin/phpunit" ]; then
+	PHPUNIT="${HOME}/vendor/bin/phpunit"
 else
 	PHPUNIT=/usr/local/bin/phpunit9
 fi

--- a/wp-test-runner/configure-environment
+++ b/wp-test-runner/configure-environment
@@ -46,11 +46,9 @@ fi
 PHP="php ${PHP_OPTIONS}"
 
 if [ -x "${APP_HOME}/vendor/bin/phpunit" ] && [ -z "${PHPUNIT_VERSION}" ]; then
-    PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
+	PHPUNIT="${APP_HOME}/vendor/bin/phpunit"
 elif [ -n "${PHPUNIT_VERSION}" ] && [ -x "/usr/local/bin/phpunit${PHPUNIT_VERSION}" ]; then
-    PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
-elif [ -x "${HOME}/vendor/bin/phpunit" ]; then
-	PHPUNIT="${HOME}/vendor/bin/phpunit"
+	PHPUNIT="/usr/local/bin/phpunit${PHPUNIT_VERSION}"
 else
 	PHPUNIT=/usr/local/bin/phpunit9
 fi

--- a/wp-test-runner/runner
+++ b/wp-test-runner/runner
@@ -2,12 +2,13 @@
 
 set -e
 
+# shellcheck source=/dev/null
 . configure-environment
 create-database
 
 : "${PHP_OPTIONS:=""}"
 : "${PHPUNIT_VERSION:=""}"
-: "${APP_HOME:="/home/ubuntu/project"}"
+: "${APP_HOME:="/home/debian/project"}"
 : "${PRETEST_SCRIPT:=""}"
 
 if [ ! -d "${APP_HOME}/vendor/yoast/phpunit-polyfills" ]; then


### PR DESCRIPTION
This pull request updates the `wp-test-runner` Docker environment to use Debian Bookworm instead of Ubuntu Noble, and standardizes on a `debian` user and home directory throughout the build and runtime scripts. The changes ensure compatibility with the new base image and improve consistency in user and directory references.

**Base image and repository changes:**
- Switched the Docker base image from `ubuntu:noble` to `debian:bookworm`, and updated the PHP package repository to use Sury's official Debian repository with its keyring for secure package installation. (`wp-test-runner/Dockerfile`) [[1]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL6-R6) [[2]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL17-R26)

**User and directory standardization:**
- Replaced all references to the `ubuntu` user and `/home/ubuntu` directory with `debian` and `/home/debian` respectively, including user creation, permissions, and environment variables. (`wp-test-runner/Dockerfile`, `configure-environment`, `runner`) [[1]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL31-R38) [[2]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL59-R64) [[3]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL72-R88) [[4]](diffhunk://#diff-c9cb2291f076b2e8a94d674a827f423106109ac2e5c2d438d84bbb330f976e13L13-R13) [[5]](diffhunk://#diff-55d8bd514a235fcc605eb4d13c0b2de87d48e3ce08988a9cafa9f46cac8016f5R5-R11)

**Script and environment adjustments:**
- Updated scripts to reference the new home directory and user, ensuring correct paths for project files and PHP tools. Also fixed logic for locating PHPUnit binaries to use `${HOME}` instead of a hardcoded path. (`configure-environment`)

These changes together improve maintainability and compatibility with the new Debian-based environment.