### PR TITLE
chore: update WordPress 7.0 to RC3

### DIFF
--- a/wordpress/versions.json
+++ b/wordpress/versions.json
@@ -1,6 +1,6 @@
 [
   {
-    "ref": "30b486f5f0db7217fde0e5b5de04e5f12ec79bc9",
+    "ref": "c0e25380377f550bc4fa72971c7eaeda052686d1",
     "tag": "7.0",
     "cacheable": false,
     "locked": true,


### PR DESCRIPTION
This pull request updates the WordPress version reference in the `versions.json` file to point to a newer commit for version 7.0.

- Updated the `ref` for the WordPress 7.0 version from `30b486f5f0db7217fde0e5b5de04e5f12ec79bc9` to `c0e25380377f550bc4fa72971c7eaeda052686d1` in `wordpress/versions.json`.