### PR TITLE
fix(photon): handle subdir network site URLs in local fetch filter

### DIFF
--- a/photon/rootfs/etc/photon/config.php
+++ b/photon/rootfs/etc/photon/config.php
@@ -10,20 +10,40 @@ define( 'JPEGTRAN', '/usr/bin/jpegtran' );
 if ( function_exists( 'add_filter' ) ) {
 	add_filter( 'override_raw_data_fetch', function ( $_overridden_data, $url ) {
 		global $remote_image_max_size;
-		if ( preg_match( '!^https?://wp-content/uploads/!', $url ) && ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
-			$path = realpath( preg_replace( '!^https?://wp-content!', $_SERVER['DOCUMENT_ROOT'], $url ) );
-			if ( str_starts_with( $path, $_SERVER['DOCUMENT_ROOT'] ) ) {
-				if ( isset( $remote_image_max_size ) && $remote_image_max_size > 0 ) {
-					$size = filesize( $path );
-					if ( $size > $remote_image_max_size ) {
-						return false;
-					}
-				}
 
-				return file_get_contents( $path );
+		if ( empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
+			return $_overridden_data;
+		}
+
+		/*
+		 * Photon builds a synthetic URL from REQUEST_URI (path is used as the "host"):
+		 * Example: https://wp-content/uploads/sites/2/2026/05/image.jpg (subdomain)
+		 * Example: https://test/wp-content/uploads/sites/2/2026/05/image.jpg (subdirectory blog at /test/)
+		 * Map to DOCUMENT_ROOT/uploads/... (wp-content/uploads is mounted at photon/uploads).
+		 */
+		if ( ! preg_match( '!/wp-content/uploads/([^?]+)!', $url, $matches ) ) {
+			return $_overridden_data;
+		}
+
+		$document_root = realpath( $_SERVER['DOCUMENT_ROOT'] );
+
+		if ( false === $document_root ) {
+			return $_overridden_data;
+		}
+
+		$path = realpath( $document_root . '/uploads/' . $matches[1] );
+		
+		if ( false === $path || ! str_starts_with( $path, $document_root ) ) {
+			return $_overridden_data;
+		}
+
+		if ( isset( $remote_image_max_size ) && $remote_image_max_size > 0 ) {
+			$size = filesize( $path );
+			if ( $size > $remote_image_max_size ) {
+				return false;
 			}
 		}
 
-		return false;
+		return file_get_contents( $path );
 	}, 10, 2 );
 }


### PR DESCRIPTION
## Summary

Photon's `override_raw_data_fetch` filter reads images directly off the mounted uploads volume instead of going over HTTP. The URL it gets is synthetic — REQUEST_URI's path is reused as the "host":

- Subdomain blog: `https://wp-content/uploads/sites/2/2026/05/image.jpg`
- Subdirectory blog at `/test/`: `https://test/wp-content/uploads/sites/2/2026/05/image.jpg`

The old regex `!^https?://wp-content/uploads/!` was anchored at the start, so the subdir form (with the blog slug `test` in the host slot) never matched and the filter returned `false` — local reads were effectively broken for subdirectory network sites when passing through Photon.

## Changes

- Unanchored regex `!/wp-content/uploads/([^?]+)!` that captures the path under `/wp-content/uploads/` regardless of what sits in the host position. The on-disk path is built explicitly from `DOCUMENT_ROOT . '/uploads/' . $matches[1]` instead of string-replacing the URL prefix.
- Return `$_overridden_data` instead of `false` when the URL isn't ours to handle, so other filters / Photon's default HTTP fetch still work.
- `realpath()` `DOCUMENT_ROOT` before the `str_starts_with` traversal guard, so symlinked document roots don't false-positive.
- `[^?]+` strips any query string before the captured path is used as a filename.

## Test plan

- [ ] Subdomain multisite: image request still serves from the local uploads volume (no regression).
- [ ] Subdirectory multisite at `/test/`: image request now serves from the local uploads volume (the bug).
- [ ] Path traversal attempt (`/wp-content/uploads/../../etc/passwd`) still rejected by the `str_starts_with` guard.
- [ ] URL with query string returns the right file.
- [ ] Non-uploads URL falls through to Photon's default fetch.
