### PR TITLE
chore: update `rsync` to 3.4.3

### DIFF
--- a/helpers/Dockerfile
+++ b/helpers/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 FROM --platform=${BUILDPLATFORM} common AS build
 ARG TARGETPLATFORM
 
-RUN xx-apk add --no-cache gcc musl-dev acl-dev acl-static attr-dev attr-static popt-dev popt-static zlib-dev zlib-static zstd-dev zstd-static
+RUN xx-apk add --no-cache gcc musl-dev acl-dev acl-static attr-dev attr-static linux-headers popt-dev popt-static zlib-dev zlib-static zstd-dev zstd-static
 RUN xx-clang --setup-target-triple
 
 WORKDIR /src/lz4-1.10.0

--- a/helpers/Dockerfile
+++ b/helpers/Dockerfile
@@ -11,13 +11,13 @@ ENV CXX=xx-clang++
 
 ADD https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz /src/
 ADD https://github.com/Cyan4973/xxHash/archive/v0.8.3.tar.gz /src/
-ADD https://download.samba.org/pub/rsync/rsync-3.4.2.tar.gz /src/
+ADD https://download.samba.org/pub/rsync/rsync-3.4.3.tar.gz /src/
 
 WORKDIR /src
 RUN \
     tar xzf lz4-1.10.0.tar.gz && \
     tar xzf v0.8.3.tar.gz && \
-    tar xzf rsync-3.4.2.tar.gz
+    tar xzf rsync-3.4.3.tar.gz
 
 COPY . .
 
@@ -30,14 +30,14 @@ RUN xx-clang --setup-target-triple
 WORKDIR /src/lz4-1.10.0
 RUN \
     make BUILD_SHARED=no CFLAGS="-O3 -flto=auto" && \
-    make -C lib install BUILD_SHARED=no PREFIX="$(xx-info sysroot)usr/local" 
+    make -C lib install BUILD_SHARED=no PREFIX="$(xx-info sysroot)usr/local"
 
 WORKDIR /src/xxHash-0.8.3
 RUN \
     make libxxhash.a CFLAGS="-DXXH_FORCE_MEMORY_ACCESS=1 -O3 -flto=auto" && \
     make install_libxxhash.a install_libxxhash.includes install_libxxhash.pc PREFIX="$(xx-info sysroot)usr/local"
 
-WORKDIR /src/rsync-3.4.2
+WORKDIR /src/rsync-3.4.3
 RUN \
     ./configure --host=$(xx-clang --print-target-triple) \
         --enable-acl-support --enable-xattr-support --disable-openssl --disable-debug --disable-md2man --disable-locale --without-included-popt --without-included-zlib \


### PR DESCRIPTION
This pull request updates the `rsync` version in the `helpers/Dockerfile` from 3.4.2 to 3.4.3. This ensures the Docker build uses the latest bug fixes and improvements from the upstream `rsync` project.

Dependency update:

* Updated the `ADD` and extraction commands to use `rsync-3.4.3.tar.gz` instead of `rsync-3.4.2.tar.gz` in `helpers/Dockerfile`.
* Changed the working directory from `/src/rsync-3.4.2` to `/src/rsync-3.4.3` to match the new version in `helpers/Dockerfile`.