### PR TITLE
build: update Debian base image

### DIFF
--- a/php-fpm/Dockerfile.82
+++ b/php-fpm/Dockerfile.82
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
-FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
+FROM debian:bookworm@sha256:85019db29298555fd1a5f4bb57673ae989414a9884117c75d7a3e1a6cce21688
 ARG TARGETARCH
 
 # Extra PHP extensions: msgpack (because of memcache)

--- a/php-fpm/Dockerfile.83
+++ b/php-fpm/Dockerfile.83
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
-FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
+FROM debian:bookworm@sha256:85019db29298555fd1a5f4bb57673ae989414a9884117c75d7a3e1a6cce21688
 ARG TARGETARCH
 
 # We lack: newrelic

--- a/php-fpm/Dockerfile.84
+++ b/php-fpm/Dockerfile.84
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
-FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
+FROM debian:bookworm@sha256:85019db29298555fd1a5f4bb57673ae989414a9884117c75d7a3e1a6cce21688
 ARG TARGETARCH
 
 # We lack: newrelic

--- a/php-fpm/Dockerfile.85
+++ b/php-fpm/Dockerfile.85
@@ -1,5 +1,5 @@
 FROM ghcr.io/automattic/vip-container-images/php-helpers:latest@sha256:5240ace0386e93c8a9a52dbfa208c3590fd0c7d599ca93b555c80a3078681caa AS build
-FROM debian:bookworm@sha256:8a8cd02c5912770b4980228a54d4aff9e4f986f1eb2525d2d371dec5232cefcc
+FROM debian:bookworm@sha256:85019db29298555fd1a5f4bb57673ae989414a9884117c75d7a3e1a6cce21688
 ARG TARGETARCH
 
 # We lack: newrelic

--- a/php-helpers/Dockerfile
+++ b/php-helpers/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=${BUILDPLATFORM} tonistiigi/xx:latest@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=${BUILDPLATFORM} debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 AS common
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS common
 ARG TARGETPLATFORM
 COPY --from=xx / /
 ENV DEBIAN_FRONTEND=noninteractive

--- a/wp-test-runner/Dockerfile
+++ b/wp-test-runner/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Base Image #
 ##############
-FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 AS base
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS base
 RUN \
 	rm -f /etc/apt/apt.conf.d/docker-clean && \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \


### PR DESCRIPTION
This pull request updates the base Debian images used in several Dockerfiles across the project. The main purpose is to keep the images up to date with the latest upstream security patches and improvements.

**Base image updates:**

* Updated the base image in `php-fpm/Dockerfile.82`, `php-fpm/Dockerfile.83`, `php-fpm/Dockerfile.84`, and `php-fpm/Dockerfile.85` from `debian:bookworm@sha256:8a8cd0...` to `debian:bookworm@sha256:85019d...` to ensure the latest security updates and bug fixes are included. [[1]](diffhunk://#diff-16cbaca8e56478d4d52f29355d40ae329aaf83cd0c0b566d532fd48689960f93L2-R2) [[2]](diffhunk://#diff-84349a488d5017189ade4b1e143a3f1832343a2abfd8a1c36ef4a1f71fe73c20L2-R2) [[3]](diffhunk://#diff-12279e235e5f547ac6124f25eec4b60c7f258b9b208a4d9d5b1b9369a2768928L2-R2) [[4]](diffhunk://#diff-cc0dad0c8531de1502f87313ecb89297a65e209b17ba6aba09fab15a4ba30604L2-R2)
* Updated the base image in `php-helpers/Dockerfile` and `wp-test-runner/Dockerfile` from `debian:bookworm-slim@sha256:f9c6a2...` to `debian:bookworm-slim@sha256:67b30a...` for improved security and compatibility. [[1]](diffhunk://#diff-3b9cbb9879da267d1dbbd81460059f467a359eb800b577776e05507048ef2da8L3-R3) [[2]](diffhunk://#diff-9760ac0241aaf0c3737885cc55a85792ce725341b960bd459ed3f97889ad1aabL6-R6)