### PR TITLE
ci: update actions

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -113,7 +113,7 @@ runs:
       if: inputs.push == 'true'
 
     - name: Attest SBOM
-      uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ steps.imagename.outputs.image_name }}
         subject-digest: ${{ steps.push.outputs.digest }}
@@ -122,7 +122,7 @@ runs:
       if: inputs.push == 'true'
 
     - name: Attest provenance
-      uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ steps.imagename.outputs.image_name }}
         subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -166,7 +166,7 @@ runs:
       if: inputs.scan == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v4.37.5
+      uses: github/codeql-action/upload-sarif@v4.37.7
       with:
         sarif_file: ${{ steps.filename.outputs.filename }}
       if: inputs.scan == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.5
+        uses: github/codeql-action/init@v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.5
+        uses: github/codeql-action/analyze@v4.37.7
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This pull request updates several GitHub Actions to their latest patch versions in both the custom `build-docker-image` action and the `codeql.yml` workflow. These updates help ensure we get the latest features and security patches from upstream actions.

**GitHub Actions version updates:**

*Docker build and security attestation:*
- Updated `actions/attest` from version `v4.2.1` to `v4.2.2` for both SBOM and provenance attestation steps in `.github/actions/build-docker-image/action.yml`. [[1]](diffhunk://#diff-7a6e84933410de3ea68c197a6f7efcdd8ba709944c714b2f297e7447b27b1d80L116-R116) [[2]](diffhunk://#diff-7a6e84933410de3ea68c197a6f7efcdd8ba709944c714b2f297e7447b27b1d80L125-R125)

*Code scanning and analysis:*
- Updated `github/codeql-action/upload-sarif` from `v4.37.5` to `v4.37.7` in `.github/actions/build-docker-image/action.yml`.
- Updated `github/codeql-action/init` and `github/codeql-action/analyze` from `v4.37.5` to `v4.37.7` in `.github/workflows/codeql.yml`.